### PR TITLE
[#20] Feature: 공통 컴포넌트 개발 (Input, Button)

### DIFF
--- a/docs/plans/020-common-components-input-button.md
+++ b/docs/plans/020-common-components-input-button.md
@@ -1,0 +1,230 @@
+# Task Plan: 공통 컴포넌트 개발 (Input, Button)
+
+**Issue**: #20
+**Type**: Feature
+**Created**: 2026-01-25
+**Status**: Completed
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+프로젝트 전반에서 재사용 가능한 공통 UI 컴포넌트가 필요합니다.
+
+- 현재 `src/shared/ui/` 폴더가 비어있으며, Button/Input 컴포넌트가 없습니다
+- 기존 코드에서 인라인 스타일로 버튼과 입력 필드를 직접 구현하고 있어 일관성이 부족합니다
+- FSD 아키텍처의 shared 레이어에 배치하여 전역적으로 재사용할 수 있는 컴포넌트가 필요합니다
+
+### Objectives
+
+1. `class-variance-authority` (CVA)를 활용한 타입 안전한 Button 컴포넌트 구현
+2. 다양한 상태를 지원하는 Input 컴포넌트 구현
+3. FSD 아키텍처에 맞는 Public API 설계
+4. Storybook을 통한 컴포넌트 문서화
+
+### Scope
+
+**In Scope**:
+
+- Button 컴포넌트 (variants, sizes, states)
+- Input 컴포넌트 (states, clearable)
+- CVA를 활용한 variant 시스템
+- TypeScript 타입 정의
+- Storybook stories 작성
+
+**Out of Scope**:
+
+- 복잡한 폼 컴포넌트 (Select, Checkbox, Radio 등)
+- 폼 유효성 검사 라이브러리 통합
+- 다크 모드 지원
+- Label/Field 컴포넌트 (별도 구현 예정)
+
+---
+
+## 2. Requirements
+
+### Functional Requirements
+
+**FR-1**: Button 컴포넌트
+
+- variant 지원: `primary`, `ghost`
+- size 지원: `sm` (32px), `md` (36px), `lg` (48px), `icon` (36x36px)
+- 상태 지원: `disabled`
+- 풀 너비 옵션: `fullWidth`
+- 라운드 버튼: `className="rounded-full"` 지원
+
+**FR-2**: Input 컴포넌트
+
+- 기본 텍스트 입력 지원
+- 상태 지원: `disabled`, `error` (boolean)
+- placeholder 지원
+- 클리어 버튼 옵션 (`clearable`, `onClear`)
+
+### Technical Requirements
+
+**TR-1**: CVA 패턴 적용
+
+- `class-variance-authority` 라이브러리 활용
+- `cn()` 유틸리티와 조합하여 className 병합
+- TypeScript 타입 추론 지원 (`VariantProps`)
+
+**TR-2**: FSD 아키텍처 준수
+
+- `src/shared/ui/` 디렉토리에 배치
+- Public API (`index.ts`)를 통한 export
+- 다른 레이어 참조 금지 (shared는 최하위 레이어)
+
+**TR-3**: 디자인 시스템
+
+- Primary 색상: `#3182F6`, hover: `#1B64DA`
+- Ghost 텍스트 색상: `#6B7583`
+- Focus ring: 3px, `#3182F6/30` opacity
+- Input border: `#EBEBEB`, focus: `#3182F6`
+
+### Non-Functional Requirements
+
+**NFR-1**: 접근성
+
+- 적절한 ARIA 속성 지원
+- 키보드 네비게이션 지원
+- focus-visible 스타일
+
+**NFR-2**: 타입 안전성
+
+- 모든 props에 대한 TypeScript 타입 정의
+- forwardRef 지원으로 ref 전달 가능
+
+---
+
+## 3. Architecture & Design
+
+### Directory Structure
+
+```
+src/shared/ui/
+├── button/
+│   ├── Button.tsx           # Button 컴포넌트
+│   ├── Button.stories.tsx   # Storybook stories
+│   └── index.ts             # Public API
+├── input/
+│   ├── Input.tsx            # Input 컴포넌트
+│   ├── Input.stories.tsx    # Storybook stories
+│   └── index.ts             # Public API
+└── index.ts                 # 통합 Public API
+```
+
+### Component Design
+
+**Button 컴포넌트**:
+
+```typescript
+const buttonVariants = cva(
+  "inline-flex items-center justify-center text-[14px] font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[#3182F6]/30 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        primary: "bg-[#3182F6] text-[#FFFFFF] hover:bg-[#1B64DA]",
+        ghost: "text-[#6B7583] hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        sm: "h-8 px-3 rounded-md",
+        md: "h-9 px-4 rounded-md",
+        lg: "h-12 px-6 rounded-lg",
+        icon: "h-9 w-9 rounded-md",
+      },
+    },
+    defaultVariants: {
+      variant: "primary",
+      size: "md",
+    },
+  },
+);
+
+interface ButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  fullWidth?: boolean;
+}
+```
+
+**Input 컴포넌트**:
+
+```typescript
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean;
+  clearable?: boolean;
+  onClear?: () => void;
+}
+```
+
+---
+
+## 4. Quality Gates
+
+### Acceptance Criteria
+
+- [x] Button 컴포넌트 구현 (variants, sizes, states)
+- [x] Input 컴포넌트 구현 (states, clearable)
+- [x] CVA를 활용한 variant 관리
+- [x] TypeScript 타입 정의
+- [x] Storybook stories 작성
+- [x] `npm run build` 성공
+- [x] `npx tsc --noEmit` 통과
+
+---
+
+## 10. Implementation Summary
+
+**Completion Date**: 2026-01-25
+**Implemented By**: Claude Opus 4.5
+
+### Changes Made
+
+**Button 컴포넌트** (`src/shared/ui/button/Button.tsx`):
+
+- CVA를 활용한 variant 시스템 구현
+- variant: `primary`, `ghost`
+- size: `sm` (32px), `md` (36px), `lg` (48px), `icon` (36x36px)
+- Primary: `bg-[#3182F6]`, hover `bg-[#1B64DA]`, text `#FFFFFF`
+- Ghost: text `#6B7583`
+- Focus ring: 3px, `#3182F6/30` opacity
+- Disabled: `opacity-50`
+- `cursor-pointer` 기본 적용
+- `fullWidth` prop 지원
+- `className="rounded-full"` 로 라운드 버튼 지원
+
+**Input 컴포넌트** (`src/shared/ui/input/Input.tsx`):
+
+- `error` prop (boolean): destructive 색상 border/focus ring
+- `clearable` + `onClear`: Button 컴포넌트 활용한 클리어 버튼
+- Focus ring: 3px, `#3182F6/30` (error 시 `destructive/30`)
+- Border: `#EBEBEB`, focus 시 `#3182F6`
+- Label은 별도 Field 컴포넌트로 분리 예정
+
+**Storybook Stories**:
+
+- `Button.stories.tsx`: Primary, Ghost, Small, Medium, Large, Disabled, FullWidth, Icon, RoundedButtons
+- `Input.stories.tsx`: Default, WithError, Disabled, Clearable
+
+### Quality Validation
+
+- [x] Build: Success
+- [x] Type Check: Passed
+
+### Files Created
+
+- `src/shared/ui/button/Button.tsx`
+- `src/shared/ui/button/Button.stories.tsx`
+- `src/shared/ui/button/index.ts`
+- `src/shared/ui/input/Input.tsx`
+- `src/shared/ui/input/Input.stories.tsx`
+- `src/shared/ui/input/index.ts`
+- `src/shared/ui/index.ts`
+
+---
+
+**Plan Status**: Completed
+**Last Updated**: 2026-01-25

--- a/src/shared/ui/button/Button.stories.tsx
+++ b/src/shared/ui/button/Button.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'shared/ui/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'ghost'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'icon'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: '시작하기',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+    children: '취소',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: '확인',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+    children: '다음',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: '제출하기',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: '비활성화',
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    fullWidth: true,
+    children: '회원가입',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '300px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Icon: Story = {
+  args: {
+    size: 'icon',
+    children: (
+      <svg
+        aria-hidden="true"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m5 12 7-7 7 7" />
+        <path d="M12 19V5" />
+      </svg>
+    ),
+    'aria-label': '위로',
+  },
+};
+
+export const RoundedButtons: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <Button className="rounded-full">시작하기</Button>
+      <Button variant="ghost" size="icon" className="rounded-full">
+        <svg
+          aria-hidden="true"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m5 12 7-7 7 7" />
+          <path d="M12 19V5" />
+        </svg>
+      </Button>
+    </div>
+  ),
+};

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -1,0 +1,49 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { forwardRef } from 'react';
+import { cn } from '@/shared/lib';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center cursor-pointer text-[14px] font-semibold leading-none transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-[#3182F6]/30 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-[#3182F6] text-[#FFFFFF] hover:bg-[#1B64DA]',
+        ghost: 'text-[#6B7583] hover:bg-accent hover:text-accent-foreground',
+      },
+      size: {
+        sm: 'h-8 px-3 rounded-md',
+        md: 'h-9 px-4 rounded-md',
+        lg: 'h-12 px-6 rounded-lg',
+        icon: 'h-9 w-9 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  }
+);
+
+interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  fullWidth?: boolean;
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, fullWidth = false, children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(buttonVariants({ variant, size }), fullWidth && 'w-full', className)}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export { Button, buttonVariants, type ButtonProps };

--- a/src/shared/ui/button/index.ts
+++ b/src/shared/ui/button/index.ts
@@ -1,0 +1,1 @@
+export { Button, type ButtonProps, buttonVariants } from './Button';

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,0 +1,2 @@
+export { Button, type ButtonProps, buttonVariants } from './button';
+export { Input, type InputProps } from './input';

--- a/src/shared/ui/input/Input.stories.tsx
+++ b/src/shared/ui/input/Input.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'shared/ui/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: {
+      control: 'text',
+    },
+    error: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    clearable: {
+      control: 'boolean',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '368px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placeholder: '텍스트를 입력하세요',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    placeholder: '이메일을 입력하세요',
+    error: true,
+    defaultValue: 'invalid-email',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: '입력할 수 없습니다',
+    disabled: true,
+  },
+};
+
+export const Clearable: Story = {
+  render: function ClearableInput() {
+    const [value, setValue] = useState('삭제 가능한 텍스트');
+
+    return (
+      <Input
+        placeholder="닉네임을 입력하세요"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        clearable
+        onClear={() => setValue('')}
+      />
+    );
+  },
+};

--- a/src/shared/ui/input/Input.tsx
+++ b/src/shared/ui/input/Input.tsx
@@ -1,0 +1,54 @@
+import { forwardRef } from 'react';
+import { Button } from '../button';
+import { svg } from '@/shared/assets';
+import { cn } from '@/shared/lib';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean;
+  clearable?: boolean;
+  onClear?: () => void;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, error, clearable = false, onClear, disabled, value, ...props }, ref) => {
+    const hasValue = value !== undefined && value !== '';
+
+    return (
+      <div className="relative">
+        <input
+          ref={ref}
+          value={value}
+          disabled={disabled}
+          className={cn(
+            'h-12 w-full rounded-md border-[1.5px] px-5 transition-colors',
+            'focus:outline-none focus-visible:ring-[3px]',
+            error
+              ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive/30'
+              : 'border-[#EBEBEB] focus-visible:border-[#3182F6] focus-visible:ring-[#3182F6]/30',
+            disabled && 'cursor-not-allowed bg-muted opacity-50',
+            clearable && hasValue && 'pr-12',
+            className
+          )}
+          aria-invalid={error ? 'true' : undefined}
+          {...props}
+        />
+        {clearable && hasValue && !disabled && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={onClear}
+            className="absolute right-4 top-1/2 h-[18px] w-[18px] -translate-y-1/2 rounded-full"
+            aria-label="입력 지우기"
+          >
+            <img src={svg.icDeleteMd} alt="" className="h-[18px] w-[18px]" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export { Input, type InputProps };

--- a/src/shared/ui/input/index.ts
+++ b/src/shared/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { Input, type InputProps } from './Input';


### PR DESCRIPTION
## 요약

- Closes #20
- FSD 아키텍처의 shared 레이어에 재사용 가능한 Button, Input 공통 컴포넌트 추가

## 변경 사항

### Button 컴포넌트 (`src/shared/ui/button/`)
- CVA를 활용한 타입 안전한 variant 시스템
- **variant**: `primary`, `ghost`
- **size**: `sm` (32px), `md` (36px), `lg` (48px), `icon` (36x36px)
- **스타일**:
  - Primary: `#3182F6`, hover `#1B64DA`, text `#FFFFFF`
  - Ghost: text `#6B7583`
  - Focus ring: 3px, `#3182F6/30` opacity
  - Disabled: `opacity-50`
- **기능**: `fullWidth`, `className="rounded-full"` 라운드 버튼 지원

### Input 컴포넌트 (`src/shared/ui/input/`)
- **상태**: `disabled`, `error` (boolean)
- **기능**: `clearable` + `onClear` (Button 컴포넌트 활용)
- **스타일**:
  - Border: `#EBEBEB`, focus 시 `#3182F6`
  - Error 시: `destructive` 색상 border/focus ring
  - Focus ring: 3px, 30% opacity
- **Note**: Label은 별도 Field 컴포넌트로 분리 예정

### Storybook
- `Button.stories.tsx`: Primary, Ghost, Small, Medium, Large, Disabled, FullWidth, Icon, RoundedButtons
- `Input.stories.tsx`: Default, WithError, Disabled, Clearable

### 문서
- Plan 문서: `docs/plans/020-common-components-input-button.md`

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인
- [x] `npm run build` 성공
- [x] `npx tsc --noEmit` 통과
