### PR TITLE
[#45] Chore: Staged 코드 lint & format 적용

### DIFF
--- a/.claude/commands/issue-start.md
+++ b/.claude/commands/issue-start.md
@@ -28,6 +28,7 @@ Before creating the GitHub issue, perform research to enrich the issue with prop
 **A. Directory and File Search**:
 
 1. Use Glob tool to find relevant files based on task type:
+
    - For UI/component tasks: Search for related components (`**/*.tsx`, `**/*.ts` in `src/components`, `src/app`)
    - For API/backend tasks: Search for API routes, server actions (`**/api/**/*.ts`, `**/actions/**/*.ts`)
    - For styling tasks: Search for CSS/styling files (`**/*.css`, `**/globals.css`)
@@ -41,6 +42,7 @@ Before creating the GitHub issue, perform research to enrich the issue with prop
 **B. Web Research** (if needed):
 
 1. Search for relevant documentation or best practices if:
+
    - The task involves unfamiliar libraries or frameworks
    - The task requires implementation of complex patterns
    - The task mentions specific technologies or APIs
@@ -67,6 +69,7 @@ Before creating the GitHub issue, perform research to enrich the issue with prop
    - Extract YAML frontmatter (if present) - this contains default labels
    - Extract markdown body sections
 3. Fill the template with analyzed information from task-analyzer (only fill relevant sections):
+
    - **Title**: Use `[Type] {title}` format where `{title}` comes from task-analyzer output
      - Map type to `[Type]` prefix:
        - `feat` → `[Feature]`

--- a/.claude/commands/task-done.md
+++ b/.claude/commands/task-done.md
@@ -21,6 +21,7 @@ Finalize task completion workflow by validating quality gates, generating implem
 ### Step 1: Find Plan Document
 
 1. **Extract Issue Number**:
+
    - Get current branch name: `git branch --show-current`
    - Parse branch format: `{type}/{issue_number}-{slug}`
    - Example: `feat/25-add-feature` → Issue #25
@@ -208,10 +209,12 @@ Generate comprehensive summary following this structure:
 ### Step 5: Append Summary to Plan Document
 
 1. **Read Current Plan**:
+
    - Load plan document from `docs/plans/{issue_number}-*.md`
    - Verify document structure
 
 2. **Append Implementation Summary**:
+
    - Add generated summary to Section 10 (Implementation Summary)
    - Preserve all other sections
    - Ensure proper markdown formatting
@@ -223,6 +226,7 @@ Generate comprehensive summary following this structure:
 ### Step 6: Clean Up Sub-Agents
 
 1. **Identify Created Agents**:
+
    - List agents created during `/task-init`:
      - react-developer
      - code-reviewer

--- a/.claude/commands/task-init.md
+++ b/.claude/commands/task-init.md
@@ -62,16 +62,19 @@ Initialize task planning workflow by analyzing GitHub issues, scanning the codeb
 Use Task tool with Explore agent (thoroughness: medium by default) to:
 
 1. **Map Directory Structure**:
+
    - Identify relevant directories for the task
    - Understand project organization patterns
    - Locate configuration files
 
 2. **Find Related Files**:
+
    - Search for components/modules related to the task
    - Identify files that will need modification
    - Find similar implementations for reference
 
 3. **Understand Architecture**:
+
    - Review existing patterns and conventions
    - Identify data flow and state management
    - Understand routing and API structure
@@ -92,11 +95,13 @@ Use Task tool with Explore agent (thoroughness: medium by default) to:
 Perform web research if needed:
 
 1. **Library Documentation**:
+
    - Search for official docs of unfamiliar libraries
    - Review API references for libraries being used
    - Check for recent changes or deprecations
 
 2. **Best Practices**:
+
    - Search for React/Next.js patterns related to the task
    - Review Vercel React best practices rules applicable to task
    - Find performance optimization techniques
@@ -135,6 +140,7 @@ Create plan document at `docs/plans/{issue_number}-{description}.md`:
 **Create specialized agents for implementation**:
 
 1. **react-developer** (always for React/Next.js tasks):
+
    - Enable `vercel-react-best-practices` skill
    - Configure focus areas based on task type:
      - Data fetching: `async-*` rules (async-defer-await, async-parallel)
@@ -143,11 +149,13 @@ Create plan document at `docs/plans/{issue_number}-{description}.md`:
      - Server: `server-*` rules (server-cache-react, server-serialization)
 
 2. **code-reviewer**:
+
    - Review code quality and adherence to best practices
    - Check for performance issues
    - Verify security considerations
 
 3. **test-writer**:
+
    - Create unit tests for new functionality
    - Update existing tests affected by changes
    - Ensure test coverage meets standards
@@ -168,11 +176,13 @@ Create plan document at `docs/plans/{issue_number}-{description}.md`:
 Present plan summary to user:
 
 1. **Show Plan Highlights**:
+
    - Key objectives and approach
    - Files that will be created/modified
    - Major design decisions
 
 2. **Display Sub-Agents**:
+
    - List agents that will be created
    - Show which best practices rules will be applied
 

--- a/.claude/skills/vercel-react-best-practices/AGENTS.md
+++ b/.claude/skills/vercel-react-best-practices/AGENTS.md
@@ -479,7 +479,7 @@ const Analytics = dynamic(
   () => import("@vercel/analytics/react").then((m) => m.Analytics),
   {
     ssr: false,
-  },
+  }
 );
 
 export default function RootLayout({ children }) {
@@ -519,7 +519,7 @@ const MonacoEditor = dynamic(
   () => import("./monaco-editor").then((m) => m.MonacoEditor),
   {
     ssr: false,
-  },
+  }
 );
 
 function CodePanel({ code }: { code: string }) {
@@ -1260,7 +1260,7 @@ function cachePrefs(user: FullUser) {
       JSON.stringify({
         theme: user.preferences.theme,
         notifications: user.preferences.notifications,
-      }),
+      })
     );
   } catch {}
 }
@@ -1436,7 +1436,7 @@ function TodoList() {
     (newItems: Item[]) => {
       setItems([...items, ...newItems]);
     },
-    [items],
+    [items]
   ); // ❌ items dependency causes recreations
 
   // Risk of stale closure if dependency is forgotten
@@ -1521,7 +1521,7 @@ function FilteredList({ items }: { items: Item[] }) {
 function UserProfile() {
   // JSON.parse runs on every render
   const [settings, setSettings] = useState(
-    JSON.parse(localStorage.getItem("settings") || "{}"),
+    JSON.parse(localStorage.getItem("settings") || "{}")
   );
 
   return <SettingsForm settings={settings} onChange={setSettings} />;
@@ -1949,14 +1949,14 @@ Use a module-level Map to cache function results when the same function is calle
 function ProjectList({ projects }: { projects: Project[] }) {
   return (
     <div>
-      {projects.map(project => {
+      {projects.map((project) => {
         // slugify() called 100+ times for same project names
-        const slug = slugify(project.name)
+        const slug = slugify(project.name);
 
-        return <ProjectCard key={project.id} slug={slug} />
+        return <ProjectCard key={project.id} slug={slug} />;
       })}
     </div>
-  )
+  );
 }
 ```
 
@@ -1964,28 +1964,28 @@ function ProjectList({ projects }: { projects: Project[] }) {
 
 ```typescript
 // Module-level cache
-const slugifyCache = new Map<string, string>()
+const slugifyCache = new Map<string, string>();
 
 function cachedSlugify(text: string): string {
   if (slugifyCache.has(text)) {
-    return slugifyCache.get(text)!
+    return slugifyCache.get(text)!;
   }
-  const result = slugify(text)
-  slugifyCache.set(text, result)
-  return result
+  const result = slugify(text);
+  slugifyCache.set(text, result);
+  return result;
 }
 
 function ProjectList({ projects }: { projects: Project[] }) {
   return (
     <div>
-      {projects.map(project => {
+      {projects.map((project) => {
         // Computed only once per unique project name
-        const slug = cachedSlugify(project.name)
+        const slug = cachedSlugify(project.name);
 
-        return <ProjectCard key={project.id} slug={slug} />
+        return <ProjectCard key={project.id} slug={slug} />;
       })}
     </div>
-  )
+  );
 }
 ```
 
@@ -2056,7 +2056,7 @@ let cookieCache: Record<string, string> | null = null;
 function getCookie(name: string) {
   if (!cookieCache) {
     cookieCache = Object.fromEntries(
-      document.cookie.split("; ").map((c) => c.split("=")),
+      document.cookie.split("; ").map((c) => c.split("="))
     );
   }
   return cookieCache[name];
@@ -2355,8 +2355,8 @@ function UserList({ users }: { users: User[] }) {
   const sorted = useMemo(
     () => users.sort((a, b) => a.name.localeCompare(b.name)),
     [users]
-  )
-  return <div>{sorted.map(renderUser)}</div>
+  );
+  return <div>{sorted.map(renderUser)}</div>;
 }
 ```
 
@@ -2368,8 +2368,8 @@ function UserList({ users }: { users: User[] }) {
   const sorted = useMemo(
     () => users.toSorted((a, b) => a.name.localeCompare(b.name)),
     [users]
-  )
-  return <div>{sorted.map(renderUser)}</div>
+  );
+  return <div>{sorted.map(renderUser)}</div>;
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-defer-third-party.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-defer-third-party.md
@@ -35,7 +35,7 @@ const Analytics = dynamic(
   () => import("@vercel/analytics/react").then((m) => m.Analytics),
   {
     ssr: false,
-  },
+  }
 );
 
 export default function RootLayout({ children }) {

--- a/.claude/skills/vercel-react-best-practices/rules/bundle-dynamic-imports.md
+++ b/.claude/skills/vercel-react-best-practices/rules/bundle-dynamic-imports.md
@@ -28,7 +28,7 @@ const MonacoEditor = dynamic(
   () => import("./monaco-editor").then((m) => m.MonacoEditor),
   {
     ssr: false,
-  },
+  }
 );
 
 function CodePanel({ code }: { code: string }) {

--- a/.claude/skills/vercel-react-best-practices/rules/client-localstorage-schema.md
+++ b/.claude/skills/vercel-react-best-practices/rules/client-localstorage-schema.md
@@ -66,7 +66,7 @@ function cachePrefs(user: FullUser) {
       JSON.stringify({
         theme: user.preferences.theme,
         notifications: user.preferences.notifications,
-      }),
+      })
     );
   } catch {}
 }

--- a/.claude/skills/vercel-react-best-practices/rules/js-cache-function-results.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-cache-function-results.md
@@ -15,14 +15,14 @@ Use a module-level Map to cache function results when the same function is calle
 function ProjectList({ projects }: { projects: Project[] }) {
   return (
     <div>
-      {projects.map(project => {
+      {projects.map((project) => {
         // slugify() called 100+ times for same project names
-        const slug = slugify(project.name)
+        const slug = slugify(project.name);
 
-        return <ProjectCard key={project.id} slug={slug} />
+        return <ProjectCard key={project.id} slug={slug} />;
       })}
     </div>
-  )
+  );
 }
 ```
 
@@ -30,28 +30,28 @@ function ProjectList({ projects }: { projects: Project[] }) {
 
 ```typescript
 // Module-level cache
-const slugifyCache = new Map<string, string>()
+const slugifyCache = new Map<string, string>();
 
 function cachedSlugify(text: string): string {
   if (slugifyCache.has(text)) {
-    return slugifyCache.get(text)!
+    return slugifyCache.get(text)!;
   }
-  const result = slugify(text)
-  slugifyCache.set(text, result)
-  return result
+  const result = slugify(text);
+  slugifyCache.set(text, result);
+  return result;
 }
 
 function ProjectList({ projects }: { projects: Project[] }) {
   return (
     <div>
-      {projects.map(project => {
+      {projects.map((project) => {
         // Computed only once per unique project name
-        const slug = cachedSlugify(project.name)
+        const slug = cachedSlugify(project.name);
 
-        return <ProjectCard key={project.id} slug={slug} />
+        return <ProjectCard key={project.id} slug={slug} />;
       })}
     </div>
-  )
+  );
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/js-cache-storage.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-cache-storage.md
@@ -46,7 +46,7 @@ let cookieCache: Record<string, string> | null = null;
 function getCookie(name: string) {
   if (!cookieCache) {
     cookieCache = Object.fromEntries(
-      document.cookie.split("; ").map((c) => c.split("=")),
+      document.cookie.split("; ").map((c) => c.split("="))
     );
   }
   return cookieCache[name];

--- a/.claude/skills/vercel-react-best-practices/rules/js-tosorted-immutable.md
+++ b/.claude/skills/vercel-react-best-practices/rules/js-tosorted-immutable.md
@@ -17,8 +17,8 @@ function UserList({ users }: { users: User[] }) {
   const sorted = useMemo(
     () => users.sort((a, b) => a.name.localeCompare(b.name)),
     [users]
-  )
-  return <div>{sorted.map(renderUser)}</div>
+  );
+  return <div>{sorted.map(renderUser)}</div>;
 }
 ```
 
@@ -30,8 +30,8 @@ function UserList({ users }: { users: User[] }) {
   const sorted = useMemo(
     () => users.toSorted((a, b) => a.name.localeCompare(b.name)),
     [users]
-  )
-  return <div>{sorted.map(renderUser)}</div>
+  );
+  return <div>{sorted.map(renderUser)}</div>;
 }
 ```
 

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-functional-setstate.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-functional-setstate.md
@@ -20,7 +20,7 @@ function TodoList() {
     (newItems: Item[]) => {
       setItems([...items, ...newItems]);
     },
-    [items],
+    [items]
   ); // ❌ items dependency causes recreations
 
   // Risk of stale closure if dependency is forgotten

--- a/.claude/skills/vercel-react-best-practices/rules/rerender-lazy-state-init.md
+++ b/.claude/skills/vercel-react-best-practices/rules/rerender-lazy-state-init.md
@@ -24,7 +24,7 @@ function FilteredList({ items }: { items: Item[] }) {
 function UserProfile() {
   // JSON.parse runs on every render
   const [settings, setSettings] = useState(
-    JSON.parse(localStorage.getItem("settings") || "{}"),
+    JSON.parse(localStorage.getItem("settings") || "{}")
   );
 
   return <SettingsForm settings={settings} onChange={setSettings} />;

--- a/docs/plans/005-add-signin-page-with-authentication-flow.md
+++ b/docs/plans/005-add-signin-page-with-authentication-flow.md
@@ -215,7 +215,7 @@ function SigninPage() {
           <Button
             variant="kakao"
             className="w-full"
-            onClick={() => console.log('Kakao login')}
+            onClick={() => console.log("Kakao login")}
           >
             <KakaoIcon />
             카카오톡으로 시작하기
@@ -224,7 +224,7 @@ function SigninPage() {
           <Button
             variant="google"
             className="w-full"
-            onClick={() => console.log('Google login')}
+            onClick={() => console.log("Google login")}
           >
             <GoogleIcon />
             구글로 시작하기
@@ -240,7 +240,7 @@ function SigninPage() {
 
 ```typescript
 interface SocialButtonProps {
-  provider: 'kakao' | 'google';
+  provider: "kakao" | "google";
   icon: React.ReactNode;
   label: string;
   onClick: () => void;
@@ -248,14 +248,14 @@ interface SocialButtonProps {
 
 function SocialButton({ provider, icon, label, onClick }: SocialButtonProps) {
   const styles = {
-    kakao: 'bg-[#FFEB00] text-black hover:bg-[#FFE500]',
-    google: 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-50',
+    kakao: "bg-[#FFEB00] text-black hover:bg-[#FFE500]",
+    google: "bg-white border border-gray-300 text-gray-700 hover:bg-gray-50",
   };
 
   return (
     <button
       className={cn(
-        'flex items-center justify-center gap-3 rounded-lg px-6 py-3 text-base font-semibold transition-colors',
+        "flex items-center justify-center gap-3 rounded-lg px-6 py-3 text-base font-semibold transition-colors",
         styles[provider]
       )}
       onClick={onClick}
@@ -770,17 +770,20 @@ npm run lint        # 린트 통과
 **Added** (Not in Original Plan):
 
 1. **Complete multi-step signin flow**:
+
    - Original plan only included initial login screen
    - Implemented full flow: login → nickname → team → (team-name | invite-link)
    - All based on user-provided mockups during implementation
 
 2. **Assets reorganization**:
+
    - Created `images/` and `svg/` folder structure
    - Implemented namespace-based import pattern
    - Established naming conventions (kebab-case → camelCase)
    - Created comprehensive documentation in `.claude/rules/assets.md`
 
 3. **Query parameter routing**:
+
    - Used `useSearchParams` instead of local state for step management
    - Enables better URL sharing and back button support
 
@@ -791,10 +794,12 @@ npm run lint        # 린트 통과
 **Changed** (Different Approach):
 
 1. **Component modularization**:
+
    - Created 5 separate step components instead of single monolithic component
    - Better separation of concerns and maintainability
 
 2. **Assets structure**:
+
    - Original plan had `src/assets/signin/` for signin-specific assets
    - Implemented global organization: `src/assets/images/` and `src/assets/svg/`
    - More scalable for entire project

--- a/docs/plans/010-fsd-project-structure.md
+++ b/docs/plans/010-fsd-project-structure.md
@@ -226,12 +226,12 @@ src/
 ```typescript
 // pages/signin/ui/SigninPage.tsx
 export function SigninPage() {
-  const [step, setStep] = useState<SigninStep>('login');
+  const [step, setStep] = useState<SigninStep>("login");
 
   return (
     <div>
-      {step === 'login' && <LoginStep onNext={() => setStep('nickname')} />}
-      {step === 'nickname' && <NicknameStep onNext={() => setStep('team')} />}
+      {step === "login" && <LoginStep onNext={() => setStep("nickname")} />}
+      {step === "nickname" && <NicknameStep onNext={() => setStep("team")} />}
       {/* ... other steps */}
     </div>
   );
@@ -243,12 +243,12 @@ export function LoginStep({ onNext }: { onNext: () => void }) {
 }
 
 // features/auth/index.ts (Public API)
-export { LoginStep } from './ui/LoginStep';
-export { NicknameStep } from './ui/NicknameStep';
-export { TeamStep } from './ui/TeamStep';
-export { TeamNameStep } from './ui/TeamNameStep';
-export { InviteLinkStep } from './ui/InviteLinkStep';
-export type { SigninStep } from './model/types';
+export { LoginStep } from "./ui/LoginStep";
+export { NicknameStep } from "./ui/NicknameStep";
+export { TeamStep } from "./ui/TeamStep";
+export { TeamNameStep } from "./ui/TeamNameStep";
+export { InviteLinkStep } from "./ui/InviteLinkStep";
+export type { SigninStep } from "./model/types";
 ```
 
 ### Data Models
@@ -616,11 +616,13 @@ npm run dev         # 개발 서버 실행
 **Phase-based Rollout**:
 
 1. **Phase 1-2**: 문서 및 Asset 정리 (기능 영향 없음)
+
    - CLAUDE.md, FSD 문서 추가
    - Asset 네이밍 변경
    - 빌드 검증
 
 2. **Phase 3**: 코드 마이그레이션 (기능 영향 있음)
+
    - Signin 코드 FSD 이동
    - Import 경로 업데이트
    - 기능 동작 검증

--- a/docs/plans/013-no-team-main-page.md
+++ b/docs/plans/013-no-team-main-page.md
@@ -140,7 +140,7 @@ src/
 // UI only - 비즈니스 로직 없음
 function NoTeamEmptyState() {
   const handleStartRetrospective = () => {
-    console.log('TODO: 회고 시작 플로우로 이동');
+    console.log("TODO: 회고 시작 플로우로 이동");
   };
 
   return (

--- a/docs/plans/018-add-cn-util.md
+++ b/docs/plans/018-add-cn-util.md
@@ -125,7 +125,7 @@ cn(
   "flex items-center",
   variant === "primary" && "bg-blue-500",
   variant === "secondary" && "bg-gray-500",
-  className,
+  className
 );
 ```
 

--- a/docs/plans/020-common-components-input-button.md
+++ b/docs/plans/020-common-components-input-button.md
@@ -139,12 +139,11 @@ const buttonVariants = cva(
       variant: "primary",
       size: "md",
     },
-  },
+  }
 );
 
 interface ButtonProps
-  extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   fullWidth?: boolean;
 }

--- a/docs/plans/024-field-common-component.md
+++ b/docs/plans/024-field-common-component.md
@@ -148,9 +148,7 @@ interface FieldProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 // data-invalid 속성으로 에러 상태 전달
-<Field data-invalid={hasError}>
-  ...
-</Field>
+<Field data-invalid={hasError}>...</Field>;
 ```
 
 **FieldLabel**:
@@ -163,17 +161,18 @@ interface FieldLabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
 // required일 때 * 표시
 <FieldLabel htmlFor="email" required>
   이메일
-</FieldLabel>
+</FieldLabel>;
 ```
 
 **FieldDescription**:
 
 ```typescript
-interface FieldDescriptionProps extends React.HTMLAttributes<HTMLParagraphElement> {}
+interface FieldDescriptionProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
 
 <FieldDescription id="email-description">
   이메일 형식으로 입력하세요
-</FieldDescription>
+</FieldDescription>;
 ```
 
 **FieldError**:
@@ -183,9 +182,7 @@ interface FieldErrorProps extends React.HTMLAttributes<HTMLParagraphElement> {
   children?: React.ReactNode;
 }
 
-<FieldError>
-  이메일 형식이 올바르지 않습니다
-</FieldError>
+<FieldError>이메일 형식이 올바르지 않습니다</FieldError>;
 ```
 
 **사용 예시 (react-hook-form)**:

--- a/docs/plans/026-radio-card-component.md
+++ b/docs/plans/026-radio-card-component.md
@@ -152,9 +152,8 @@ src/shared/ui/
 **RadioCardGroup**:
 
 ```typescript
-interface RadioCardGroupProps extends React.ComponentPropsWithoutRef<
-  typeof RadioGroup.Root
-> {
+interface RadioCardGroupProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroup.Root> {
   className?: string;
   children: React.ReactNode;
 }
@@ -165,9 +164,8 @@ interface RadioCardGroupProps extends React.ComponentPropsWithoutRef<
 **RadioCardItem**:
 
 ```typescript
-interface RadioCardItemProps extends React.ComponentPropsWithoutRef<
-  typeof RadioGroup.Item
-> {
+interface RadioCardItemProps
+  extends React.ComponentPropsWithoutRef<typeof RadioGroup.Item> {
   className?: string;
   children: React.ReactNode;
 }

--- a/docs/plans/028-calendar-component.md
+++ b/docs/plans/028-calendar-component.md
@@ -198,7 +198,7 @@ const dayVariants = cva(
     defaultVariants: {
       state: "default",
     },
-  },
+  }
 );
 ```
 

--- a/docs/plans/034-checkbox-component.md
+++ b/docs/plans/034-checkbox-component.md
@@ -163,10 +163,8 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 ### Data Models
 
 ```typescript
-interface CheckboxProps extends Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "type"
-> {
+interface CheckboxProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
   /** 체크박스 옆에 표시할 레이블 텍스트 */
   label?: string;
 }

--- a/docs/plans/043-dialog-component.md
+++ b/docs/plans/043-dialog-component.md
@@ -1,0 +1,391 @@
+# Task Plan: Dialog 공통 컴포넌트 구현
+
+**Issue**: #43
+**Type**: Feature
+**Created**: 2026-01-31
+**Status**: Planning
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+프로젝트에서 모달, 확인 다이얼로그, 알림 등에 재사용 가능한 공통 Dialog 컴포넌트가 필요합니다.
+
+- 현재 공통 UI 컴포넌트(Button, Input, Accordion 등)는 있지만 Dialog는 없음
+- Dialog는 여러 곳에서 반복적으로 필요한 UI 패턴
+- 일관된 사용자 경험과 접근성 보장 필요
+
+### Objectives
+
+1. Radix UI Dialog 기반 공통 Dialog 컴포넌트 구현
+2. 기존 Accordion 패턴(Primitive/headless)을 따라 일관성 유지
+3. Storybook 문서화로 팀 내 사용법 공유
+
+### Scope
+
+**In Scope**:
+
+- Dialog 컴포넌트 구현 (Root, Trigger, Content, Header, Footer 등)
+- Storybook 문서 작성
+- 접근성(WAI-ARIA) 준수
+
+**Out of Scope**:
+
+- AlertDialog (별도 이슈로 분리)
+- 애니메이션/트랜지션 (추후 개선)
+- 드래그/리사이즈 기능
+
+### User Context
+
+> "className 오버라이드로 하자"
+> 피그마에 252px, 400px, 434px, 708px 다이얼로그 width 존재
+
+**핵심 요구사항**:
+
+1. Width는 size variant 없이 className 오버라이드 방식 (shadcn 스타일)
+2. 기본 max-width 설정 후 사용처에서 커스텀 가능
+
+---
+
+## 2. Requirements
+
+### Functional Requirements
+
+**FR-1**: Dialog 열기/닫기
+
+- Trigger 클릭 시 Dialog 열림
+- Overlay 클릭, Close 버튼, ESC 키로 닫힘
+- 외부에서 open/onOpenChange로 제어 가능 (Controlled)
+
+**FR-2**: 포커스 관리
+
+- Dialog 열릴 때 Content로 포커스 이동
+- Dialog 닫힐 때 Trigger로 포커스 복귀
+- Tab 키로 Dialog 내부 요소 간 이동 (포커스 트랩)
+
+**FR-3**: 스크롤 잠금
+
+- Dialog 열릴 때 body 스크롤 비활성화
+- Dialog 닫힐 때 스크롤 복원
+
+### Technical Requirements
+
+**TR-1**: 기술 스택
+
+- @radix-ui/react-dialog 사용 (새로 설치 필요)
+- Tailwind CSS로 스타일링
+- forwardRef로 ref 전달
+
+**TR-2**: 컴포넌트 구조
+
+- Compound Component 패턴 (Accordion과 동일)
+- className 오버라이드로 width 커스텀
+- 기본 max-width: `sm:max-w-lg` (512px)
+
+### Non-Functional Requirements
+
+**NFR-1**: 접근성
+
+- role="dialog", aria-modal="true"
+- aria-labelledby, aria-describedby 연결
+- 키보드 네비게이션 지원
+
+**NFR-2**: 성능
+
+- Portal로 렌더링하여 z-index 이슈 방지
+- 닫힌 상태에서 Content 언마운트
+
+---
+
+## 3. Architecture & Design
+
+### Directory Structure
+
+```
+src/shared/ui/dialog/
+├── Dialog.tsx              # 메인 컴포넌트
+└── Dialog.stories.tsx      # Storybook 문서
+```
+
+### Design Decisions
+
+**Decision 1**: Radix UI Dialog 사용
+
+- **Rationale**: 접근성, 포커스 관리, 스크롤 잠금 등 복잡한 기능이 이미 구현됨
+- **Approach**: @radix-ui/react-dialog 설치 후 래핑
+- **Trade-offs**: 번들 크기 증가 vs 직접 구현 대비 안정성/접근성 보장
+- **Alternatives Considered**: 직접 구현 (Accordion처럼) - 복잡도가 높아 Radix 선택
+- **Impact**: LOW (약 5KB gzipped 추가)
+
+**Decision 2**: className 오버라이드 방식 (shadcn 스타일)
+
+- **Rationale**: 사용자 요청, 피그마 width 값이 다양함 (252px, 400px, 434px, 708px)
+- **Implementation**: 기본 `sm:max-w-lg` 제공, 사용처에서 className으로 오버라이드
+- **Benefit**: 유연성 극대화, 디자인 변경에 쉽게 대응
+
+### Component Design
+
+**서브 컴포넌트**:
+
+```typescript
+// Radix 래핑 컴포넌트
+DialogRoot; // = Dialog.Root (상태 관리)
+DialogTrigger; // = Dialog.Trigger (열기 버튼)
+DialogPortal; // = Dialog.Portal (Portal 렌더링)
+DialogOverlay; // = Dialog.Overlay (배경)
+DialogContent; // = Dialog.Content (메인 콘텐츠)
+DialogClose; // = Dialog.Close (닫기 버튼)
+
+// 레이아웃 헬퍼 (순수 div)
+DialogHeader; // 헤더 영역
+DialogFooter; // 푸터 영역
+DialogTitle; // 제목 (aria-labelledby)
+DialogDescription; // 설명 (aria-describedby)
+```
+
+**사용 예시**:
+
+```tsx
+<DialogRoot>
+  <DialogTrigger>열기</DialogTrigger>
+  <DialogPortal>
+    <DialogOverlay className="fixed inset-0 bg-black/50" />
+    <DialogContent className="sm:max-w-[400px]">
+      <DialogHeader>
+        <DialogTitle>제목</DialogTitle>
+        <DialogDescription>설명</DialogDescription>
+      </DialogHeader>
+      <div>내용</div>
+      <DialogFooter>
+        <DialogClose>닫기</DialogClose>
+      </DialogFooter>
+    </DialogContent>
+  </DialogPortal>
+</DialogRoot>
+```
+
+### Data Models
+
+```typescript
+// Radix Dialog props 재사용
+interface DialogRootProps
+  extends React.ComponentPropsWithoutRef<typeof Dialog.Root> {}
+interface DialogTriggerProps
+  extends React.ComponentPropsWithoutRef<typeof Dialog.Trigger> {}
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof Dialog.Content> {}
+// ... 등
+
+// 레이아웃 헬퍼 props
+interface DialogHeaderProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface DialogFooterProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface DialogTitleProps
+  extends React.ComponentPropsWithoutRef<typeof Dialog.Title> {}
+interface DialogDescriptionProps
+  extends React.ComponentPropsWithoutRef<typeof Dialog.Description> {}
+```
+
+---
+
+## 4. Implementation Plan
+
+### Phase 1: Setup
+
+**Tasks**:
+
+1. @radix-ui/react-dialog 설치
+2. `src/shared/ui/dialog/` 폴더 생성
+
+**Commands**:
+
+```bash
+pnpm add @radix-ui/react-dialog
+```
+
+**Estimated Effort**: Small
+
+### Phase 2: Core Implementation
+
+**Tasks**:
+
+1. Dialog.tsx 작성
+   - Radix Dialog 컴포넌트 래핑
+   - DialogContent 기본 스타일 적용 (centered, overlay)
+   - DialogHeader/Footer/Title/Description 레이아웃 헬퍼
+
+**Files to Create**:
+
+- `src/shared/ui/dialog/Dialog.tsx` (CREATE)
+
+**Dependencies**: Phase 1 완료
+
+### Phase 3: Documentation
+
+**Tasks**:
+
+1. Storybook 작성
+   - Default 스토리
+   - With Form 스토리
+   - Custom Width 스토리 (252px, 400px, 434px, 708px)
+   - Controlled 스토리
+
+**Files to Create**:
+
+- `src/shared/ui/dialog/Dialog.stories.tsx` (CREATE)
+
+### Vercel React Best Practices
+
+**CRITICAL**:
+
+- `bundle-barrel-imports`: 직접 import 사용 (index.ts 없음)
+
+**MEDIUM**:
+
+- `rerender-memo`: Dialog 내부 불필요한 리렌더링 방지
+
+---
+
+## 5. Quality Gates
+
+### Testing Strategy
+
+**TS-1**: Storybook 시각적 테스트
+
+- 다양한 width로 렌더링 확인
+- 열기/닫기 동작 확인
+- 오버레이 클릭 닫기 확인
+
+**TS-2**: 빌드 및 타입 체크
+
+```bash
+npm run build        # 빌드 성공 필수
+npx tsc --noEmit    # 타입 오류 없음
+npm run lint        # 린트 통과
+```
+
+### Acceptance Criteria
+
+- [x] Dialog 컴포넌트 구현 (`src/shared/ui/dialog/Dialog.tsx`)
+- [ ] Storybook 작성 (`src/shared/ui/dialog/Dialog.stories.tsx`)
+- [ ] 빌드 성공 (`npm run build`)
+- [ ] 타입 검사 통과 (`npx tsc --noEmit`)
+- [ ] 린트 통과 (`npm run lint`)
+
+### Validation Checklist
+
+**기능 동작**:
+
+- [ ] Trigger 클릭 시 Dialog 열림
+- [ ] Overlay 클릭 시 닫힘
+- [ ] ESC 키로 닫힘
+- [ ] Close 버튼으로 닫힘
+
+**코드 품질**:
+
+- [ ] TypeScript 에러 없음
+- [ ] 린트 경고 없음
+
+**접근성**:
+
+- [ ] 키보드 네비게이션 동작 (Tab, Shift+Tab)
+- [ ] ESC로 닫기
+- [ ] aria-labelledby, aria-describedby 연결
+
+---
+
+## 6. Risks & Dependencies
+
+### Risks
+
+**R-1**: Radix UI 버전 호환성
+
+- **Risk**: React 19와의 호환성 이슈 가능성
+- **Impact**: MEDIUM
+- **Probability**: LOW
+- **Mitigation**: 최신 버전 설치 후 테스트
+
+### Dependencies
+
+**D-1**: @radix-ui/react-dialog
+
+- **Dependency**: npm 패키지 설치 필요
+- **Required For**: 모든 Dialog 기능
+- **Status**: NOT INSTALLED
+- **Action**: Phase 1에서 설치
+
+---
+
+## 7. Rollout & Monitoring
+
+### Deployment Strategy
+
+1. 컴포넌트 구현 및 Storybook 문서화
+2. PR 리뷰 및 머지
+3. 팀 내 사용 가이드 공유
+
+### Success Metrics
+
+**SM-1**: 컴포넌트 완성도
+
+- **Metric**: 모든 서브 컴포넌트 구현
+- **Target**: 10개 컴포넌트
+
+**SM-2**: Storybook 문서화
+
+- **Metric**: 스토리 개수
+- **Target**: 4개 이상 (Default, Form, CustomWidth, Controlled)
+
+---
+
+## 8. Timeline & Milestones
+
+### Milestones
+
+**M1**: 패키지 설치 및 기본 구조
+
+- Radix UI Dialog 설치
+- 폴더 구조 생성
+
+**M2**: 컴포넌트 구현
+
+- 모든 서브 컴포넌트 구현
+- 기본 스타일 적용
+
+**M3**: 문서화 완료
+
+- Storybook 작성
+- 사용 예시 포함
+
+---
+
+## 9. References
+
+### Related Issues
+
+- Issue #43: [Dialog 공통 컴포넌트 구현](https://github.com/YAPP-Github/27th-Web-Team-3-FE/issues/43)
+
+### Documentation
+
+**프로젝트 문서**:
+
+- [CLAUDE.md](../../CLAUDE.md)
+- [FSD 아키텍처](./.claude/rules/fsd.md)
+
+### External Resources
+
+- [Radix UI Dialog](https://www.radix-ui.com/docs/primitives/components/dialog)
+- [shadcn/ui Dialog](https://ui.shadcn.com/docs/components/dialog)
+
+---
+
+## 10. Implementation Summary
+
+> **Note**: 이 섹션은 작업 완료 후 `/task-done` 커맨드가 자동으로 채웁니다.
+
+---
+
+**Plan Status**: Planning
+**Last Updated**: 2026-01-31
+**Next Action**: 사용자 승인 후 구현 시작

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/index.css
+++ b/src/index.css
@@ -5,10 +5,10 @@
 
 @theme inline {
   --font-sans:
-    "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
-    system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo",
-    "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol", sans-serif;
+    "Pretendard Variable", Pretendard, -apple-system,
+    BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI",
+    "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -5,7 +5,9 @@ interface HeaderProps {
 export function Header({ className }: HeaderProps) {
   return (
     <header
-      className={`h-[54px] bg-[#FFFFFF] border-b border-[#F3F4F5] flex items-center justify-between px-4 ${className ?? ''}`}
+      className={`h-[54px] bg-[#FFFFFF] border-b border-[#F3F4F5] flex items-center justify-between px-4 ${
+        className ?? ''
+      }`}
     >
       {/* TODO: 실제 로고와 프로필 아바타로 교체 */}
       <div className="w-8 h-8 rounded bg-gray-200" />


### PR DESCRIPTION
## 요약

- Closes #45
- 로컬에서 수정된 파일들에 lint 및 format 적용

## 변경 사항

- `.claude/commands/` - Claude 커맨드 파일 업데이트 (3개)
- `.claude/skills/vercel-react-best-practices/` - 스킬 규칙 파일 포맷팅 (9개)
- `docs/plans/` - 계획 문서 포맷팅 및 Dialog 컴포넌트 계획 추가 (11개)
- `src/shared/ui/dialog/` - Dialog 컴포넌트 및 Storybook 추가
- `src/shared/assets/icons/` - Back, Close 아이콘 SVG 추가
- `src/shared/ui/icons/` - IcBack, IcClose 컴포넌트 추가
- `index.html`, `src/index.css`, `src/widgets/header/ui/Header.tsx` - 소스 코드 포맷팅

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인

🤖 Generated with [Claude Code](https://claude.ai/code)