### PR TITLE
[#74] Bug: 소셜 로그인 시 token API 중복 호출 이슈 수정

### DIFF
--- a/docs/plans/074-fix-duplicate-token-api-call.md
+++ b/docs/plans/074-fix-duplicate-token-api-call.md
@@ -1,0 +1,244 @@
+# Task Plan: 소셜 로그인 시 token API 중복 호출 이슈 수정
+
+**Issue**: #74
+**Type**: Bug
+**Created**: 2026-02-02
+**Status**: Planning
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+소셜 로그인(Google/Kakao) 시 OAuth 콜백 페이지에서 토큰 교환 API가 3번 연속 호출되는 문제가 발생합니다.
+
+- `CallbackPage.tsx`의 `useEffect` 의존성 배열에 `socialLoginMutation` 객체가 포함됨
+- `useMutation` 훅이 반환하는 mutation 객체는 매 렌더링마다 새로운 참조를 가짐
+- React 18 Strict Mode(개발 모드)의 이중 실행과 합쳐져 총 3번 호출
+
+### Objectives
+
+1. OAuth 처리 로직이 정확히 1번만 실행되도록 수정
+2. 불필요한 API 호출로 인한 리소스 낭비 방지
+3. 잠재적 오류 가능성 제거
+
+### Scope
+
+**In Scope**:
+
+- `CallbackPage.tsx`의 중복 실행 방지 로직 추가
+
+**Out of Scope**:
+
+- OAuth 인증 플로우 변경
+- 다른 페이지의 useEffect 최적화
+
+---
+
+## 2. Requirements
+
+### Functional Requirements
+
+**FR-1**: OAuth 처리 로직 단일 실행 보장
+
+- `processOAuth()` 함수가 컴포넌트 생명주기 동안 정확히 1번만 실행되어야 함
+- React Strict Mode에서도 중복 실행 방지
+
+### Technical Requirements
+
+**TR-1**: useRef를 사용한 실행 상태 추적
+
+- `useRef`로 이미 처리가 시작되었는지 추적
+- 의존성 배열은 그대로 유지 (ESLint 규칙 준수)
+
+---
+
+## 3. Architecture & Design
+
+### Design Decisions
+
+**Decision 1**: useRef 패턴 사용
+
+- **Rationale**: ESLint `exhaustive-deps` 규칙을 위반하지 않으면서 중복 실행 방지
+- **Approach**: `hasProcessed` ref를 사용하여 이미 처리 중인지 체크
+- **Alternatives Considered**:
+  - 의존성 배열에서 `socialLoginMutation` 제거 → ESLint 경고 발생, 권장하지 않음
+  - `useCallback`으로 mutation 래핑 → 근본적 해결이 아님
+- **Impact**: LOW - 코드 변경 최소화
+
+### Component Design
+
+**Before**:
+
+```typescript
+useEffect(() => {
+  if (isAuthenticated) {
+    navigate("/", { replace: true });
+    return;
+  }
+
+  const processOAuth = async () => {
+    // OAuth 처리 로직
+  };
+
+  processOAuth();
+}, [isAuthenticated, login, navigate, setSignupData, socialLoginMutation]);
+```
+
+**After**:
+
+```typescript
+const hasProcessed = useRef(false);
+
+useEffect(() => {
+  if (isAuthenticated) {
+    navigate("/", { replace: true });
+    return;
+  }
+
+  if (hasProcessed.current) return;
+  hasProcessed.current = true;
+
+  const processOAuth = async () => {
+    // OAuth 처리 로직
+  };
+
+  processOAuth();
+}, [isAuthenticated, login, navigate, setSignupData, socialLoginMutation]);
+```
+
+---
+
+## 4. Implementation Plan
+
+### Phase 1: Core Fix
+
+**Tasks**:
+
+1. `useRef` import 추가
+2. `hasProcessed` ref 선언
+3. `useEffect` 내부에 중복 실행 방지 가드 추가
+
+**Files to Modify**:
+
+- `src/pages/callback/ui/CallbackPage.tsx` (MODIFY)
+
+**Estimated Effort**: Small
+
+---
+
+## 5. Quality Gates
+
+### Testing Strategy
+
+**TS-1**: 수동 테스트
+
+- Google 소셜 로그인 테스트
+- Kakao 소셜 로그인 테스트
+- Network 탭에서 token API 호출 횟수 확인 (1번만 호출되어야 함)
+
+**TS-2**: 빌드 및 타입 체크
+
+```bash
+npm run build        # 빌드 성공 필수
+npx tsc --noEmit    # 타입 오류 없음
+npm run lint        # 린트 통과
+```
+
+### Acceptance Criteria
+
+- [x] `useRef`를 사용하여 OAuth 처리 로직의 중복 실행 방지
+- [ ] 소셜 로그인 시 token API가 1번만 호출되는지 확인
+- [ ] 빌드 및 타입 체크 통과
+
+---
+
+## 6. Risks & Dependencies
+
+### Risks
+
+**R-1**: OAuth 코드 재사용 문제
+
+- **Risk**: 동일 authorization code를 여러 번 사용하면 OAuth provider가 거부할 수 있음
+- **Impact**: HIGH
+- **Mitigation**: `useRef`로 단일 실행 보장하여 해결
+
+---
+
+## 7. References
+
+### Related Issues
+
+- Issue #74: [소셜 로그인 시 token API 중복 호출 이슈 수정](https://github.com/YAPP-Github/27th-Web-Team-3-FE/issues/74)
+
+### External Resources
+
+- [React 18 Strict Mode](https://react.dev/reference/react/StrictMode)
+- [useRef Hook](https://react.dev/reference/react/useRef)
+
+---
+
+## 10. Implementation Summary
+
+**Completion Date**: 2026-02-02
+**Implemented By**: Claude Opus 4.5
+
+### Changes Made
+
+#### Files Modified
+
+- [`src/pages/callback/ui/CallbackPage.tsx`](../src/pages/callback/ui/CallbackPage.tsx#L10) - `mutateAsync` 추출로 안정적인 참조 사용
+
+#### Key Implementation Details
+
+**계획 변경**: 원래 `useRef` 패턴을 계획했으나, 사용자와 논의 후 더 근본적인 해결책인 `mutateAsync` 추출 방식으로 변경
+
+**변경 내용**:
+
+```diff
+- const socialLoginMutation = useSocialLogin();
++ const { mutateAsync: socialLogin } = useSocialLogin();
+
+- const response = await socialLoginMutation.mutateAsync({...});
++ const response = await socialLogin({...});
+
+- }, [isAuthenticated, login, navigate, setSignupData, socialLoginMutation]);
++ }, [isAuthenticated, login, navigate, setSignupData, socialLogin]);
+```
+
+**왜 이 방식이 더 나은가**:
+
+- `mutateAsync`는 TanStack Query에서 **안정적인 참조** 보장
+- mutation 객체 전체는 상태 변경 시 새 참조 생성 → `useEffect` 재실행 유발
+- `mutateAsync`만 추출하면 참조가 변하지 않음 → 근본적인 중복 실행 방지
+
+### Quality Validation
+
+- [x] Build: Success
+- [x] Type Check: Passed
+- [x] Lint: Passed (biome format 적용)
+- [x] Deploy Test: https://moaofficial.kr 배포 완료
+
+### Deviations from Plan
+
+**Changed**:
+
+- `useRef` 패턴 대신 `mutateAsync` 추출 방식 사용
+- 이유: 더 React스럽고 근본적인 해결책, ESLint 규칙 완전 준수
+
+### Performance Impact
+
+- Bundle size: 변화 없음 (코드 라인 수 동일)
+- Runtime: 중복 API 호출 제거로 성능 개선
+
+### Notes
+
+- TanStack Query의 `mutateAsync`는 안정적인 참조를 보장하므로 의존성 배열에 안전하게 포함 가능
+- Production 환경에서도 중복 호출 문제가 발생했으므로 해당 수정이 필수적이었음
+
+---
+
+**Plan Status**: Completed
+**Last Updated**: 2026-02-02
+**Next Action**: PR 생성

--- a/src/pages/callback/ui/CallbackPage.tsx
+++ b/src/pages/callback/ui/CallbackPage.tsx
@@ -7,7 +7,7 @@ import { useAuthStore } from '@/features/auth/model/store';
 export function CallbackPage() {
   const navigate = useNavigate();
   const { isAuthenticated, login, setSignupData } = useAuthStore();
-  const socialLoginMutation = useSocialLogin();
+  const { mutateAsync: socialLogin } = useSocialLogin();
 
   useEffect(() => {
     // 이미 로그인된 상태면 메인으로 리다이렉트
@@ -27,7 +27,7 @@ export function CallbackPage() {
       try {
         const accessToken = await exchangeCodeForToken(oauthData.code, oauthData.provider);
 
-        const response = await socialLoginMutation.mutateAsync({
+        const response = await socialLogin({
           accessToken,
           provider: oauthData.provider as unknown as 'GOOGLE' | 'KAKAO',
         });
@@ -52,7 +52,7 @@ export function CallbackPage() {
     };
 
     processOAuth();
-  }, [isAuthenticated, login, navigate, setSignupData, socialLoginMutation]);
+  }, [isAuthenticated, login, navigate, setSignupData, socialLogin]);
 
   return (
     <div className="flex h-screen items-center justify-center bg-white">


### PR DESCRIPTION
## 요약

- Closes #74
- 소셜 로그인(Google/Kakao) 시 OAuth 콜백 페이지에서 토큰 교환 API가 3번 연속 호출되는 문제 수정

## 변경 사항

- `useSocialLogin()`에서 `mutateAsync`만 추출하여 안정적인 참조 사용
- mutation 객체 전체가 아닌 `mutateAsync` 함수만 의존성 배열에 포함하여 불필요한 `useEffect` 재실행 방지

```diff
- const socialLoginMutation = useSocialLogin();
+ const { mutateAsync: socialLogin } = useSocialLogin();
```

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인

## 테스트

- [x] 빌드 성공
- [x] 타입 체크 통과
- [x] 린트 통과
- [x] Vercel 배포 테스트 완료 (https://moaofficial.kr)
