### PR TITLE
[#86] Feature: Avatar 공통 컴포넌트 구현

### DIFF
--- a/docs/plans/086-add-avatar-component.md
+++ b/docs/plans/086-add-avatar-component.md
@@ -1,0 +1,376 @@
+# Task Plan: Avatar 공통 컴포넌트 구현
+
+**Issue**: #86
+**Type**: Feature
+**Created**: 2026-02-03
+**Status**: Planning
+
+---
+
+## 1. Overview
+
+### Problem Statement
+
+사용자 프로필, 팀원 목록 등에서 아바타를 표시할 수 있는 공통 컴포넌트가 필요합니다.
+
+- 현재 프로젝트에 Avatar 컴포넌트가 없어 사용자 이미지를 일관되게 표시할 방법이 없음
+- 이미지 로드 실패 시 fallback 처리가 필요함
+- 다양한 크기와 스타일을 지원해야 함
+
+### Objectives
+
+1. 기존 컴포넌트 패턴(cva + forwardRef)을 따르는 Avatar 컴포넌트 구현
+2. 다양한 크기(xs, sm, md, lg, xl) 지원
+3. 이미지, 텍스트(이니셜), fallback 아이콘 지원
+4. Storybook 스토리 작성
+
+### Scope
+
+**In Scope**:
+
+- Avatar 컴포넌트 구현 (`src/shared/ui/avatar/Avatar.tsx`)
+- Storybook 스토리 작성 (`src/shared/ui/avatar/Avatar.stories.tsx`)
+- TypeScript 타입 정의
+- 이미지 로드 실패 시 fallback 처리
+
+**Out of Scope**:
+
+- Avatar 그룹 컴포넌트 (AvatarGroup)
+- 온라인 상태 표시 (presence indicator)
+- 애니메이션 효과
+
+---
+
+## 2. Requirements
+
+### Functional Requirements
+
+**FR-1**: 이미지 Avatar 표시
+
+- 이미지 URL을 받아 원형 아바타로 표시
+- `src` prop으로 이미지 URL 전달
+- `alt` prop으로 대체 텍스트 제공
+
+**FR-2**: Fallback 처리
+
+- 이미지 로드 실패 시 자동으로 fallback 표시
+- 텍스트(이니셜) fallback 지원
+- 기본 아이콘 fallback 지원
+
+**FR-3**: 다양한 크기 지원
+
+- xs (24px), sm (28px), md (32px), lg (36px), xl (48px)
+- 기존 IconButton과 동일한 크기 체계 사용
+
+### Technical Requirements
+
+**TR-1**: 기존 컴포넌트 패턴 준수
+
+- cva (class-variance-authority) 사용
+- forwardRef 패턴 적용
+- cn 유틸리티로 className 병합
+
+**TR-2**: 이미지 로딩 상태 관리
+
+- React useState로 이미지 로딩 상태 관리
+- onError 이벤트로 로드 실패 감지
+- 외부 라이브러리 없이 순수 React로 구현
+
+### Non-Functional Requirements
+
+**NFR-1**: 접근성
+
+- 이미지에 적절한 alt 텍스트 제공
+- role="img" 또는 적절한 ARIA 속성 사용
+- 스크린 리더 지원
+
+**NFR-2**: 성능
+
+- 이미지 lazy loading 지원 (optional)
+- 불필요한 리렌더링 방지
+
+---
+
+## 3. Architecture & Design
+
+### Directory Structure
+
+```
+src/shared/ui/
+└── avatar/
+    ├── Avatar.tsx           # 메인 컴포넌트 (CREATE)
+    └── Avatar.stories.tsx   # Storybook 스토리 (CREATE)
+```
+
+### Design Decisions
+
+**Decision 1**: 외부 라이브러리 없이 순수 React로 구현
+
+- **Rationale**: 프로젝트에 Radix UI가 설치되어 있지 않으며, 간단한 Avatar 컴포넌트는 순수 React로 충분히 구현 가능
+- **Approach**: useState로 이미지 로딩 상태 관리, onError 이벤트로 fallback 처리
+- **Trade-offs**: Radix UI의 delayMs 같은 고급 기능은 없지만, 추가 의존성 없음
+- **Impact**: LOW
+
+**Decision 2**: 기존 IconButton 크기 체계 사용
+
+- **Rationale**: 디자인 시스템 일관성 유지
+- **Implementation**: IconButton과 동일한 size variants (xs, sm, md, lg, xl)
+- **Benefit**: 다른 컴포넌트와 조합 시 크기 일관성
+
+### Component Design
+
+**Avatar 컴포넌트 구조**:
+
+```typescript
+interface AvatarProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof avatarVariants> {
+  src?: string;
+  alt?: string;
+  fallback?: React.ReactNode;
+}
+
+const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(
+  ({ src, alt, fallback, size, className, ...props }, ref) => {
+    const [imageError, setImageError] = useState(false);
+    const showFallback = !src || imageError;
+
+    return (
+      <span
+        ref={ref}
+        className={cn(avatarVariants({ size }), className)}
+        {...props}
+      >
+        {showFallback ? (
+          <span className="fallback">{fallback || getInitials(alt)}</span>
+        ) : (
+          <img src={src} alt={alt} onError={() => setImageError(true)} />
+        )}
+      </span>
+    );
+  }
+);
+```
+
+### Data Models
+
+```typescript
+// Size variants
+type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+// Props interface
+interface AvatarProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof avatarVariants> {
+  /** 이미지 URL */
+  src?: string;
+  /** 대체 텍스트 (이미지 설명, 이니셜 생성에도 사용) */
+  alt?: string;
+  /** 이미지 로드 실패 시 표시할 fallback 콘텐츠 */
+  fallback?: React.ReactNode;
+}
+```
+
+---
+
+## 4. Implementation Plan
+
+### Phase 1: Core Implementation
+
+**Tasks**:
+
+1. Avatar 컴포넌트 파일 생성
+2. cva variants 정의 (size)
+3. 이미지 로딩 상태 관리 로직 구현
+4. Fallback 렌더링 로직 구현
+
+**Files to Create/Modify**:
+
+- `src/shared/ui/avatar/Avatar.tsx` (CREATE)
+
+**Estimated Effort**: Small
+
+### Phase 2: Storybook Stories
+
+**Tasks**:
+
+1. Storybook 스토리 파일 생성
+2. 각 크기별 스토리 작성
+3. Fallback 시나리오 스토리 작성
+4. 이미지/텍스트/아이콘 fallback 예시
+
+**Files to Create/Modify**:
+
+- `src/shared/ui/avatar/Avatar.stories.tsx` (CREATE)
+
+**Dependencies**: Phase 1 완료 필요
+
+### Phase 3: Quality Validation
+
+**Tasks**:
+
+1. 빌드 검증
+2. 타입 체크
+3. 린트 검증
+4. Storybook에서 시각적 확인
+
+### Vercel React Best Practices
+
+**MEDIUM**:
+
+- `rerender-memo`: 불필요한 리렌더링 방지 (이미지 로딩 상태만 변경 시 리렌더)
+
+---
+
+## 5. Quality Gates
+
+### Testing Strategy
+
+**TS-1**: Storybook Visual Testing
+
+- 테스트 타입: Visual
+- 모든 크기 조합 확인
+- 이미지 로드 성공/실패 시나리오 확인
+
+**TS-2**: 빌드 및 타입 체크
+
+```bash
+npm run build        # 빌드 성공 필수
+npx tsc --noEmit    # 타입 오류 없음
+npm run lint        # 린트 통과
+```
+
+### Acceptance Criteria
+
+- [x] Avatar 컴포넌트 구현 (다양한 크기 지원)
+- [x] 이미지 로드 실패 시 fallback 처리
+- [x] Storybook 스토리 작성
+- [x] TypeScript 타입 정의
+- [ ] Build 성공
+- [ ] Type check 성공
+- [ ] Lint 통과
+
+### Validation Checklist
+
+**기능 동작**:
+
+- [ ] 이미지 URL로 아바타 표시
+- [ ] 이미지 없을 때 fallback 표시
+- [ ] 이미지 로드 실패 시 fallback 표시
+- [ ] 모든 크기(xs~xl) 정상 렌더링
+
+**코드 품질**:
+
+- [ ] TypeScript 에러 없음
+- [ ] 린트 경고 없음
+- [ ] 기존 컴포넌트 패턴 준수
+
+**접근성**:
+
+- [ ] 이미지에 alt 텍스트 적용
+- [ ] 적절한 role 속성
+
+---
+
+## 6. Risks & Dependencies
+
+### Risks
+
+**R-1**: 이미지 CORS 이슈
+
+- **Risk**: 외부 이미지 URL 사용 시 CORS 에러 발생 가능
+- **Impact**: LOW
+- **Probability**: LOW
+- **Mitigation**: onError 핸들러로 fallback 처리
+- **Status**: 대응 방안 마련됨
+
+### Dependencies
+
+**D-1**: 기존 유틸리티
+
+- **Dependency**: `@/shared/lib/cn` (className 병합 유틸리티)
+- **Required For**: className 조합
+- **Status**: AVAILABLE
+
+**D-2**: class-variance-authority
+
+- **Dependency**: `class-variance-authority` 패키지
+- **Required For**: Variant 스타일 관리
+- **Status**: AVAILABLE (package.json에 설치됨)
+
+---
+
+## 7. Rollout & Monitoring
+
+### Deployment Strategy
+
+1. Phase 1: Avatar 컴포넌트 구현 및 테스트
+2. Phase 2: Storybook 스토리 추가
+3. Phase 3: PR 생성 및 리뷰
+
+### Success Metrics
+
+**SM-1**: 컴포넌트 완성도
+
+- **Metric**: 모든 크기 variant 정상 동작
+- **Target**: 100%
+- **Measurement**: Storybook 시각적 확인
+
+---
+
+## 8. Timeline & Milestones
+
+### Milestones
+
+**M1**: Core Implementation
+
+- Avatar 컴포넌트 구현 완료
+- **Status**: NOT_STARTED
+
+**M2**: Storybook Stories
+
+- 모든 스토리 작성 완료
+- **Status**: NOT_STARTED
+
+**M3**: Quality Validation
+
+- 빌드/타입/린트 통과
+- **Status**: NOT_STARTED
+
+---
+
+## 9. References
+
+### Related Issues
+
+- Issue #86: [Feature] Avatar 공통 컴포넌트 구현
+
+### Documentation
+
+**프로젝트 문서**:
+
+- [CLAUDE.md](../../CLAUDE.md)
+- [.claude/rules/fsd.md](../../.claude/rules/fsd.md)
+
+### External Resources
+
+- [Radix UI Avatar](https://www.radix-ui.com/primitives/docs/components/avatar) - 참고용 API 디자인
+
+### Code References
+
+**참고 컴포넌트**:
+
+- `src/shared/ui/button/Button.tsx` - cva + forwardRef 패턴
+- `src/shared/ui/icon-button/IconButton.tsx` - 크기 체계 참고
+
+---
+
+## 10. Implementation Summary
+
+> **Note**: 이 섹션은 작업 완료 후 `/task-done` 커맨드가 자동으로 채웁니다.
+
+---
+
+**Plan Status**: Planning
+**Last Updated**: 2026-02-03
+**Next Action**: 사용자 승인 후 구현 시작

--- a/src/shared/ui/avatar/Avatar.stories.tsx
+++ b/src/shared/ui/avatar/Avatar.stories.tsx
@@ -1,0 +1,195 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Avatar } from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'shared/ui/Avatar',
+  component: Avatar,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+    },
+    src: {
+      control: 'text',
+    },
+    alt: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 샘플 이미지 URL
+const sampleImageUrl =
+  'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=128&h=128&fit=crop&crop=face';
+
+// 기본 (이미지)
+export const Default: Story = {
+  args: {
+    src: sampleImageUrl,
+    alt: 'John Doe',
+    size: 'md',
+  },
+};
+
+// 이미지 Avatar
+export const WithImage: Story = {
+  args: {
+    src: sampleImageUrl,
+    alt: 'User Avatar',
+    size: 'lg',
+  },
+};
+
+// 이니셜 Fallback (영문)
+export const WithInitialsEnglish: Story = {
+  args: {
+    alt: 'John Doe',
+    size: 'lg',
+  },
+};
+
+// 이니셜 Fallback (한글)
+export const WithInitialsKorean: Story = {
+  args: {
+    alt: '홍길동',
+    size: 'lg',
+  },
+};
+
+// 커스텀 Fallback
+export const WithCustomFallback: Story = {
+  args: {
+    fallback: '🎉',
+    size: 'lg',
+  },
+};
+
+// 빈 Avatar (회색 배경만)
+export const Empty: Story = {
+  args: {
+    size: 'lg',
+  },
+};
+
+// 이미지 로드 실패 시
+export const ImageLoadError: Story = {
+  args: {
+    src: 'https://invalid-url.com/image.jpg',
+    alt: 'Error User',
+    size: 'lg',
+  },
+};
+
+// 모든 크기
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-4">
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="xs" src={sampleImageUrl} alt="XS" />
+        <span className="text-xs text-gray-500">xs</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="sm" src={sampleImageUrl} alt="SM" />
+        <span className="text-xs text-gray-500">sm</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="md" src={sampleImageUrl} alt="MD" />
+        <span className="text-xs text-gray-500">md</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" src={sampleImageUrl} alt="LG" />
+        <span className="text-xs text-gray-500">lg</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="xl" src={sampleImageUrl} alt="XL" />
+        <span className="text-xs text-gray-500">xl</span>
+      </div>
+    </div>
+  ),
+};
+
+// 모든 크기 (이니셜)
+export const AllSizesWithInitials: Story = {
+  render: () => (
+    <div className="flex items-end gap-4">
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="xs" alt="John Doe" />
+        <span className="text-xs text-gray-500">xs</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="sm" alt="John Doe" />
+        <span className="text-xs text-gray-500">sm</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="md" alt="John Doe" />
+        <span className="text-xs text-gray-500">md</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" alt="John Doe" />
+        <span className="text-xs text-gray-500">lg</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="xl" alt="John Doe" />
+        <span className="text-xs text-gray-500">xl</span>
+      </div>
+    </div>
+  ),
+};
+
+// 다양한 Fallback 유형
+export const FallbackVariants: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" src={sampleImageUrl} alt="이미지" />
+        <span className="text-xs text-gray-500">이미지</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" alt="John Doe" />
+        <span className="text-xs text-gray-500">영문 이니셜</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" alt="홍길동" />
+        <span className="text-xs text-gray-500">한글 이니셜</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" fallback="🚀" />
+        <span className="text-xs text-gray-500">이모지</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar size="lg" />
+        <span className="text-xs text-gray-500">빈 배경</span>
+      </div>
+    </div>
+  ),
+};
+
+// 실제 사용 예시 (팀원 목록)
+export const TeamMemberList: Story = {
+  render: () => (
+    <div className="flex -space-x-2">
+      <Avatar
+        size="md"
+        src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=128&h=128&fit=crop&crop=face"
+        alt="팀원 1"
+        className="ring-2 ring-white"
+      />
+      <Avatar
+        size="md"
+        src="https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=128&h=128&fit=crop&crop=face"
+        alt="팀원 2"
+        className="ring-2 ring-white"
+      />
+      <Avatar size="md" alt="김철수" className="ring-2 ring-white" />
+      <Avatar size="md" alt="이영희" className="ring-2 ring-white" />
+      <Avatar size="md" fallback="+3" className="ring-2 ring-white text-xs" />
+    </div>
+  ),
+};

--- a/src/shared/ui/avatar/Avatar.tsx
+++ b/src/shared/ui/avatar/Avatar.tsx
@@ -1,0 +1,87 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import { forwardRef, useState } from 'react';
+import { cn } from '@/shared/lib/cn';
+
+const avatarVariants = cva(
+  'relative inline-flex items-center justify-center overflow-hidden rounded-full bg-[#F3F4F5] text-[#6B7583] font-medium select-none',
+  {
+    variants: {
+      size: {
+        xs: 'size-6 text-[10px]', // 24px
+        sm: 'size-7 text-xs', // 28px
+        md: 'size-8 text-xs', // 32px
+        lg: 'size-9 text-sm', // 36px
+        xl: 'size-12 text-base', // 48px
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+);
+
+/**
+ * alt 텍스트에서 이니셜을 추출합니다.
+ * 예: "John Doe" → "JD", "홍길동" → "홍"
+ */
+function getInitials(name?: string): string {
+  if (!name) return '';
+
+  const words = name.trim().split(/\s+/);
+
+  // 한글인 경우 첫 글자만
+  if (/[\u3131-\u318E\uAC00-\uD7A3]/.test(name)) {
+    return words[0]?.charAt(0) || '';
+  }
+
+  // 영문인 경우 각 단어의 첫 글자 (최대 2글자)
+  return words
+    .slice(0, 2)
+    .map((word) => word.charAt(0).toUpperCase())
+    .join('');
+}
+
+interface AvatarProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof avatarVariants> {
+  /** 이미지 URL */
+  src?: string;
+  /** 대체 텍스트 (이미지 설명, 이니셜 생성에도 사용) */
+  alt?: string;
+  /** 이미지 로드 실패 시 표시할 fallback 콘텐츠 */
+  fallback?: React.ReactNode;
+}
+
+const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(
+  ({ src, alt, fallback, size, className, ...props }, ref) => {
+    const [imageError, setImageError] = useState(false);
+    const showFallback = !src || imageError;
+
+    return (
+      <span
+        ref={ref}
+        role="img"
+        aria-label={alt}
+        className={cn(avatarVariants({ size }), className)}
+        {...props}
+      >
+        {showFallback ? (
+          fallback || getInitials(alt) ? (
+            <span className="flex items-center justify-center">{fallback || getInitials(alt)}</span>
+          ) : null
+        ) : (
+          <img
+            src={src}
+            alt={alt || ''}
+            className="size-full object-cover"
+            onError={() => setImageError(true)}
+          />
+        )}
+      </span>
+    );
+  }
+);
+
+Avatar.displayName = 'Avatar';
+
+export { Avatar, avatarVariants, getInitials, type AvatarProps };

--- a/src/shared/ui/dropdown-menu/DropdownMenu.stories.tsx
+++ b/src/shared/ui/dropdown-menu/DropdownMenu.stories.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './DropdownMenu';
+import { Avatar } from '@/shared/ui/avatar/Avatar';
 import { Button } from '@/shared/ui/button/Button';
 import { IconButton } from '@/shared/ui/icon-button/IconButton';
 import IcMeatball from '@/shared/ui/icons/IcMeatball';
@@ -313,6 +314,55 @@ export const WithDangerItem: Story = {
               onSelect={() => console.log('삭제')}
             >
               삭제
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenuPortal>
+      </DropdownMenuRoot>
+    );
+  },
+};
+
+const sampleImageUrl =
+  'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=128&h=128&fit=crop&crop=face';
+
+export const WithAvatarTrigger: Story = {
+  name: 'With Avatar Trigger (프로필 드롭다운)',
+  render: () => {
+    return (
+      <DropdownMenuRoot>
+        <DropdownMenuTrigger>
+          <button
+            type="button"
+            className="inline-flex p-0 border-0 bg-transparent rounded-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-[#3182F6]/30"
+          >
+            <Avatar size="md" src={sampleImageUrl} alt="홍길동" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuPortal>
+          <DropdownMenuContent
+            align="end"
+            className="min-w-[180px] rounded-lg border border-[#EBEBEB] bg-white p-1 shadow-lg"
+          >
+            <div className="flex items-center gap-3 px-3 py-2">
+              <Avatar size="sm" src={sampleImageUrl} alt="홍길동" />
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-[#333D4B]">홍길동</span>
+                <span className="text-xs text-[#6B7583]">hong@example.com</span>
+              </div>
+            </div>
+            <DropdownMenuSeparator className={separatorClassName} />
+            <DropdownMenuItem className={itemClassName} onSelect={() => console.log('프로필')}>
+              프로필
+            </DropdownMenuItem>
+            <DropdownMenuItem className={itemClassName} onSelect={() => console.log('설정')}>
+              설정
+            </DropdownMenuItem>
+            <DropdownMenuSeparator className={separatorClassName} />
+            <DropdownMenuItem
+              className={`${itemClassName} text-red-500 hover:bg-red-50 data-[highlighted]:bg-red-50`}
+              onSelect={() => console.log('로그아웃')}
+            >
+              로그아웃
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenuPortal>


### PR DESCRIPTION
## 요약

- Closes #86
- 사용자 프로필, 팀원 목록 등에서 사용할 수 있는 Avatar 공통 컴포넌트를 구현합니다.

## 변경 사항

- **Avatar 컴포넌트 구현** (`src/shared/ui/avatar/Avatar.tsx`)
  - 다양한 크기 지원 (xs: 24px, sm: 28px, md: 32px, lg: 36px, xl: 48px)
  - 이미지 로드 실패 시 fallback 처리 (이니셜 → 회색 배경)
  - 영문(2글자)/한글(1글자) 이니셜 자동 추출
  - cva + forwardRef 패턴으로 기존 컴포넌트와 일관성 유지

- **Storybook 스토리 추가** (`src/shared/ui/avatar/Avatar.stories.tsx`)
  - 이미지/이니셜/커스텀 fallback 예시
  - 모든 크기 variant 예시
  - 팀원 목록 사용 예시

- **DropdownMenu 스토리 추가** (`src/shared/ui/dropdown-menu/DropdownMenu.stories.tsx`)
  - Avatar를 트리거로 사용하는 프로필 드롭다운 예시

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인
