### PR TITLE
[#122] Bug: 회고 방식 라벨에 RETROSPECT_METHOD_LABELS 적용

### DIFF
--- a/src/features/retrospective/model/constants.ts
+++ b/src/features/retrospective/model/constants.ts
@@ -10,7 +10,7 @@ export const RETROSPECT_METHOD_LABELS: Record<string, string> = {
 
 export const RETROSPECT_METHOD_DESCRIPTIONS: Record<string, string> = {
   [RetrospectMethod.KPT]: '스프린트 단위 프로젝트를 회고할 때',
-  [RetrospectMethod.FOUR_L]: '팀 분위기와 관계, 배움을 돌아볼 떄',
+  [RetrospectMethod.FOUR_L]: '팀 분위기와 관계, 배움을 돌아볼 때',
   [RetrospectMethod.FIVE_F]: '중장기 프로젝트를 회고할 때',
   [RetrospectMethod.PMI]: '빠른 회고가 필요할 때',
   [RetrospectMethod.FREE]: '맞춤형 회고를 진행할때',

--- a/src/features/retrospective/ui/steps/CompleteStep.tsx
+++ b/src/features/retrospective/ui/steps/CompleteStep.tsx
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
+import { RETROSPECT_METHOD_LABELS } from '@/features/retrospective/model/constants';
 import { IconButton } from '@/shared/ui/icon-button/IconButton';
 import IcClose from '@/shared/ui/icons/IcClose';
 import IcLink from '@/shared/ui/icons/IcLink';
@@ -70,7 +71,9 @@ export function CompleteStep({
             </div>
             <div className="flex items-center gap-2">
               <span className="text-caption-3-medium text-grey-800">회고 유형</span>
-              <span className="text-caption-4 text-grey-700">{retrospectMethod}</span>
+              <span className="text-caption-4 text-grey-700">
+                {RETROSPECT_METHOD_LABELS[retrospectMethod] ?? retrospectMethod}
+              </span>
             </div>
           </div>
         </div>

--- a/src/pages/team-dashboard/ui/TeamDashboardPage.tsx
+++ b/src/pages/team-dashboard/ui/TeamDashboardPage.tsx
@@ -3,6 +3,7 @@ import { ko } from 'date-fns/locale';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { useRetrospects } from '@/features/retrospective/api/retrospective.queries';
+import { RETROSPECT_METHOD_LABELS } from '@/features/retrospective/model/constants';
 import { CompletedRetrospectiveModal } from '@/features/retrospective/ui/CompletedRetrospectiveModal';
 import { CreateRetrospectDialog } from '@/features/retrospective/ui/CreateRetrospectDialog';
 import { RetrospectSection } from '@/features/retrospective/ui/RetrospectSection';
@@ -212,7 +213,8 @@ export function TeamDashboardPage() {
                       </span>
                       <div className="flex items-center gap-1">
                         <span className="text-caption-3 font-medium text-grey-700">
-                          {retro.retrospectMethod}
+                          {RETROSPECT_METHOD_LABELS[retro.retrospectMethod] ??
+                            retro.retrospectMethod}
                         </span>
                         <span className="text-caption-3 font-medium text-grey-700">·</span>
                         <span className="text-caption-3 font-medium text-grey-700">


### PR DESCRIPTION
## Summary

- 회고 완료 화면(`CompleteStep`)과 팀 대시보드 오늘 회고 목록에서 raw enum 값(`FOUR_L`, `FIVE_F` 등) 대신 `RETROSPECT_METHOD_LABELS`를 사용하여 사람이 읽기 쉬운 라벨(`4L`, `5F`, `자유 회고` 등)을 표시하도록 수정
- `RETROSPECT_METHOD_DESCRIPTIONS`의 `FOUR_L` 항목 오타 수정 (`돌아볼 떄` → `돌아볼 때`)

Closes #122

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/features/retrospective/ui/steps/CompleteStep.tsx` | `RETROSPECT_METHOD_LABELS` import 및 적용 |
| `src/pages/team-dashboard/ui/TeamDashboardPage.tsx` | `RETROSPECT_METHOD_LABELS` import 및 적용 |
| `src/features/retrospective/model/constants.ts` | 오타 수정 |

## Test plan

- [ ] 회고 생성 완료 화면에서 회고 유형이 `KPT`, `4L`, `5F`, `PMI`, `자유 회고`로 표시되는지 확인
- [ ] 팀 대시보드 오늘 회고 목록에서 회고 방식이 올바른 라벨로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)