### PR TITLE
[#155] Fix: currentUserStatus 서버 응답 값 동기화 및 분석 탭 개선

### DIFF
--- a/docs/plans/155-fix-current-user-status-mismatch.md
+++ b/docs/plans/155-fix-current-user-status-mismatch.md
@@ -1,0 +1,44 @@
+# [#155] Fix: currentUserStatus 값 불일치로 임시저장/제출 에러 발생
+
+## 1. Overview
+
+서버 API(`GET /api/v1/retrospects/{retrospectId}`)의 `currentUserStatus` 응답 값이 `NOT_JOINED`에서 `NOT_PARTICIPATED`로 변경되었으나, 프론트엔드 코드가 여전히 `NOT_JOINED`을 기대하고 있어 회고 임시저장/제출 에러가 발생하고 있다.
+
+서버 측에서 member에 상태를 추가하는 작업 과정에서 enum 값이 변경된 것으로 추정.
+
+## 2. Requirements
+
+### 기능 요구사항
+- **FR-1**: `currentUserStatus` 타입을 서버 응답에 맞게 `NOT_PARTICIPATED`로 변경
+- **FR-2**: 회고 작성 페이지에서 참가자 자동 등록이 정상 동작해야 함
+- **FR-3**: 임시저장/제출이 에러 없이 동작해야 함
+
+## 3. Architecture & Design
+
+단순 enum 값 변경이므로 아키텍처 변경 없음. `NOT_JOINED` → `NOT_PARTICIPATED` 문자열 교체.
+
+## 4. Implementation Plan
+
+### 변경 파일 목록
+
+| # | 파일 | 변경 내용 |
+|---|------|----------|
+| 1 | `src/features/retrospective/model/types.ts:113` | 타입 `'NOT_JOINED'` → `'NOT_PARTICIPATED'` |
+| 2 | `src/pages/retrospective-write/ui/WritePageContent.tsx:100-102` | 비교 문자열 + 주석 변경 |
+| 3 | `src/shared/api/mocks/fixtures/retrospective.ts:102,211,247` | mock 타입 및 데이터 변경 |
+| 4 | `src/shared/api/mocks/handlers/retrospective.ts:41` | fallback mock 데이터 변경 |
+
+### 변경하지 않는 파일
+- `src/shared/api/generated/index.ts` — Orval 자동 생성 파일 (참조용, 직접 수정 X)
+
+## 5. Quality Gates
+
+- [x] `pnpm run build` 성공
+- [x] `pnpm tsc --noEmit` 통과
+- [x] `pnpm run lint` 통과
+- [x] 모든 `NOT_JOINED` 참조가 `NOT_PARTICIPATED`로 변경됨
+
+## 6. Risks & Dependencies
+
+- **Low Risk**: 단순 문자열 값 변경이므로 사이드 이펙트 최소
+- **Dependency**: 서버 API가 실제로 `NOT_PARTICIPATED`를 반환하는지 확인 필요 (사용자가 확인 완료)

--- a/src/features/retrospective/api/retrospective.mutations.ts
+++ b/src/features/retrospective/api/retrospective.mutations.ts
@@ -19,6 +19,7 @@ import type {
   DraftSaveRequest,
   SubmitRetrospectRequest,
 } from '../model/types';
+import { ApiError } from '@/shared/api/error';
 
 export function useCreateRetrospect(retroRoomId: number) {
   const queryClient = useQueryClient();
@@ -111,8 +112,14 @@ export function useAnalyzeRetrospective(retrospectId: number) {
 
   return useMutation({
     mutationFn: () => analyzeRetrospective(retrospectId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: retrospectiveQueryKeys.analysis(retrospectId) });
+    onSuccess: (data) => {
+      queryClient.setQueryData(retrospectiveQueryKeys.analysis(retrospectId), data);
     },
+    onError: (error) => {
+      if (error instanceof ApiError && error.status === 409) {
+        queryClient.refetchQueries({ queryKey: retrospectiveQueryKeys.analysis(retrospectId) });
+      }
+    },
+    meta: { skipGlobalError: true },
   });
 }

--- a/src/features/retrospective/api/retrospective.queries.ts
+++ b/src/features/retrospective/api/retrospective.queries.ts
@@ -8,6 +8,7 @@ import {
   listRetrospects,
 } from './retrospective.api';
 import type { ResponseCategory } from '../model/types';
+import { ApiError } from '@/shared/api/error';
 
 export const retrospectiveQueryKeys = {
   list: (retroRoomId: number) => ['retrospects', retroRoomId] as const,
@@ -62,10 +63,14 @@ export function useComments(responseId: number) {
 }
 
 export function useAnalysisResult(retrospectId: number) {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: retrospectiveQueryKeys.analysis(retrospectId),
     queryFn: () => getAnalysisResult(retrospectId),
     staleTime: 1000 * 60 * 5,
+    retry: (_, error) => {
+      if (error instanceof ApiError && error.status === 404) return false;
+      return false;
+    },
   });
 }
 

--- a/src/features/retrospective/model/types.ts
+++ b/src/features/retrospective/model/types.ts
@@ -110,7 +110,7 @@ export interface RetrospectMemberItem {
 }
 
 export interface RetrospectDetailResponse {
-  currentUserStatus: 'NOT_JOINED' | 'DRAFT' | 'SUBMITTED';
+  currentUserStatus: 'NOT_PARTICIPATED' | 'IN_PROGRESS' | 'SUBMITTED';
   members: RetrospectMemberItem[];
   questions: RetrospectQuestionItem[];
   retroCategory: RetrospectMethod;

--- a/src/features/retrospective/ui/detail/AnalysisEmptyState.tsx
+++ b/src/features/retrospective/ui/detail/AnalysisEmptyState.tsx
@@ -24,9 +24,9 @@ export function AnalysisEmptyState({
     <div className="flex flex-1 flex-col items-center justify-center gap-4">
       <IcNote width={28.5} />
       <p className="text-center text-sub-title-4 text-grey-800">
-        현재까지 작성된 회고를 기반으로
+        {mutation.isPending ? 'AI가 회고를 분석하고 있어요' : '현재까지 작성된 회고를 기반으로'}
         <br />
-        인사이트가 생성돼요
+        {mutation.isPending ? '잠시만 기다려주세요' : '인사이트가 생성돼요'}
       </p>
       <div className="flex items-center gap-1 text-caption-3-medium text-grey-700">
         <IcUser width={16} height={16} />
@@ -36,12 +36,17 @@ export function AnalysisEmptyState({
       </div>
       <button
         type="button"
-        className="flex h-[36px] cursor-pointer items-center justify-center gap-1 rounded-[6px] border border-blue-100 bg-linear-to-r from-[#EEF5FF] to-[#F2FFFB] py-[7px] pr-[14px] pl-[10px]"
+        className="flex h-[36px] cursor-pointer items-center justify-center gap-1 rounded-[6px] border border-blue-100 bg-linear-to-r from-[#EEF5FF] to-[#F2FFFB] py-[7px] pr-[14px] pl-[10px] disabled:cursor-not-allowed disabled:opacity-50"
         onClick={handleAnalyze}
+        disabled={mutation.isPending}
       >
-        <IcAiSpark width={18} height={18} />
+        {mutation.isPending ? (
+          <div className="h-[18px] w-[18px] animate-spin rounded-full border-2 border-blue-200 border-t-blue-500" />
+        ) : (
+          <IcAiSpark width={18} height={18} />
+        )}
         <span className="bg-linear-to-r from-[#3182F6] to-[#52E79D] bg-clip-text text-[14px] font-semibold leading-none text-transparent">
-          AI 회고 분석 하기
+          {mutation.isPending ? '분석 중...' : 'AI 회고 분석 하기'}
         </span>
       </button>
     </div>

--- a/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
+++ b/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
@@ -43,13 +43,11 @@ function DetailContent({ retrospectId, teamId }: { retrospectId: number; teamId:
               </Suspense>
             )}
             {activeTab === 'analysis' && (
-              <Suspense fallback={null}>
-                <AnalysisTabContent
-                  retrospectId={retrospectId}
-                  participantCount={detail.members.length}
-                  totalParticipants={detail.members.length}
-                />
-              </Suspense>
+              <AnalysisTabContent
+                retrospectId={retrospectId}
+                participantCount={detail.members.length}
+                totalParticipants={detail.members.length}
+              />
             )}
           </div>
         </div>

--- a/src/pages/retrospective-write/ui/WritePageContent.tsx
+++ b/src/pages/retrospective-write/ui/WritePageContent.tsx
@@ -97,9 +97,9 @@ export function WritePageContent({ retrospectId, teamId, detail }: WritePageCont
   const submitMutation = useSubmitRetrospect(retrospectId);
   const assistantMutation = useAssistantGuide(retrospectId, currentQuestionIndex + 1);
 
-  // ---- 참가자 등록 (NOT_JOINED인 경우 한 번만) ----
+  // ---- 참가자 등록 (NOT_PARTICIPATED인 경우 한 번만) ----
   useEffect(() => {
-    if (detail.currentUserStatus === 'NOT_JOINED' && !hasRegisteredParticipant.current) {
+    if (detail.currentUserStatus === 'NOT_PARTICIPATED' && !hasRegisteredParticipant.current) {
       hasRegisteredParticipant.current = true;
       createParticipantMutation.mutate();
     }

--- a/src/shared/api/mocks/fixtures/retrospective.ts
+++ b/src/shared/api/mocks/fixtures/retrospective.ts
@@ -99,7 +99,7 @@ export const retrospects: Record<
 export const retrospectDetails: Record<
   number,
   {
-    currentUserStatus: 'NOT_JOINED' | 'DRAFT' | 'SUBMITTED';
+    currentUserStatus: 'NOT_PARTICIPATED' | 'IN_PROGRESS' | 'SUBMITTED';
     members: { memberId: number; userName: string }[];
     questions: { content: string; index: number }[];
     retroCategory: string;
@@ -111,7 +111,7 @@ export const retrospectDetails: Record<
   }
 > = {
   101: {
-    currentUserStatus: 'DRAFT',
+    currentUserStatus: 'IN_PROGRESS',
     members: [
       { memberId: 1, userName: '홍길동' },
       { memberId: 2, userName: '김철수' },
@@ -149,7 +149,7 @@ export const retrospectDetails: Record<
     totalLikeCount: 3,
   },
   103: {
-    currentUserStatus: 'DRAFT',
+    currentUserStatus: 'IN_PROGRESS',
     members: [
       { memberId: 1, userName: '홍길동' },
       { memberId: 2, userName: '김철수' },
@@ -208,7 +208,7 @@ export const retrospectDetails: Record<
     totalLikeCount: 15,
   },
   201: {
-    currentUserStatus: 'NOT_JOINED',
+    currentUserStatus: 'NOT_PARTICIPATED',
     members: [
       { memberId: 1, userName: '김민지' },
       { memberId: 4, userName: '손민수' },
@@ -244,7 +244,7 @@ export const retrospectDetails: Record<
     totalLikeCount: 4,
   },
   301: {
-    currentUserStatus: 'NOT_JOINED',
+    currentUserStatus: 'NOT_PARTICIPATED',
     members: [
       { memberId: 5, userName: '박지훈' },
       { memberId: 6, userName: '최수아' },

--- a/src/shared/api/mocks/handlers/retrospective.ts
+++ b/src/shared/api/mocks/handlers/retrospective.ts
@@ -38,7 +38,7 @@ export const retrospectiveHandlers = [
     if (detail) return successResponse(detail);
 
     return successResponse({
-      currentUserStatus: 'NOT_JOINED',
+      currentUserStatus: 'NOT_PARTICIPATED',
       members: [],
       questions: [{ content: '질문 1', index: 0 }],
       retroCategory: 'KPT',


### PR DESCRIPTION
## Summary

- 서버 API의 `currentUserStatus` enum 변경에 맞춰 프론트엔드 코드 동기화 (`NOT_JOINED` → `NOT_PARTICIPATED`, `DRAFT` → `IN_PROGRESS`)
- 회고 분석 탭에서 404 에러 시 페이지 이탈되는 문제 수정
- 분석 버튼 클릭 시 로딩 UI 추가 및 이미 분석 완료된 회고(409) 처리

## Changes

### currentUserStatus 동기화
- `NOT_JOINED` → `NOT_PARTICIPATED`: 참가자 자동 등록 조건 수정
- `DRAFT` → `IN_PROGRESS`: 타입 정의 및 mock 데이터 수정

### 분석 탭 개선
- `useSuspenseQuery` → `useQuery`로 변경하여 404 시 `ApiErrorBoundary`에 잡히지 않도록 수정
- 탭 진입 시 GET으로 기존 분석 결과 조회, 없으면 빈 상태 UI 표시
- "AI 회고 분석 하기" 버튼에 로딩 스피너, 텍스트 변경, disabled 처리 추가
- 이미 분석 완료된 회고(409)에 대해 글로벌 토스트 억제 후 GET refetch로 기존 결과 표시

## Test plan

- [ ] 회고 작성 페이지 진입 시 참가자 자동 등록 정상 동작 확인
- [ ] 임시저장/제출이 에러 없이 동작하는지 확인
- [ ] 회고 분석 탭 클릭 시 페이지 이탈 없이 빈 상태 UI 표시 확인
- [ ] "AI 회고 분석 하기" 버튼 클릭 시 로딩 UI 표시 확인
- [ ] 이미 분석 완료된 회고 재진입 시 결과 바로 표시 확인

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)