### PR TITLE
[#161] Bug: 완료된 회고 댓글 UI 및 팀 없음 화면 디테일 개선

### DIFF
--- a/src/features/retrospective/ui/detail/CommentInput.tsx
+++ b/src/features/retrospective/ui/detail/CommentInput.tsx
@@ -4,10 +4,12 @@ import { Button } from '@/shared/ui/button/Button';
 
 interface CommentInputProps {
   responseId: number;
+  initialContent: string;
+  onContentChange: (content: string) => void;
 }
 
-export function CommentInput({ responseId }: CommentInputProps) {
-  const [content, setContent] = useState('');
+export function CommentInput({ responseId, initialContent, onContentChange }: CommentInputProps) {
+  const [content, setContent] = useState(initialContent);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const mutation = useCreateComment(responseId);
 
@@ -15,19 +17,18 @@ export function CommentInput({ responseId }: CommentInputProps) {
     textareaRef.current?.focus();
   }, []);
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setContent(e.target.value);
+    onContentChange(e.target.value);
+  };
+
   const handleSubmit = async () => {
     const trimmed = content.trim();
     if (!trimmed) return;
 
     await mutation.mutateAsync({ content: trimmed });
     setContent('');
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSubmit();
-    }
+    onContentChange('');
   };
 
   return (
@@ -35,8 +36,7 @@ export function CommentInput({ responseId }: CommentInputProps) {
       <textarea
         ref={textareaRef}
         value={content}
-        onChange={(e) => setContent(e.target.value)}
-        onKeyDown={handleKeyDown}
+        onChange={handleChange}
         placeholder="댓글로 의견을 남겨보세요"
         rows={1}
         className="max-h-[120px] flex-1 resize-none bg-transparent text-caption-3-medium leading-[normal] text-grey-900 outline-none [field-sizing:content] placeholder:text-grey-500"

--- a/src/features/retrospective/ui/detail/CommentSection.tsx
+++ b/src/features/retrospective/ui/detail/CommentSection.tsx
@@ -4,15 +4,21 @@ import { Avatar } from '@/shared/ui/avatar/Avatar';
 
 interface CommentSectionProps {
   responseId: number;
+  draft: string;
+  onDraftChange: (content: string) => void;
 }
 
-export function CommentSection({ responseId }: CommentSectionProps) {
+export function CommentSection({ responseId, draft, onDraftChange }: CommentSectionProps) {
   const { data, isLoading } = useComments(responseId);
   const comments = data?.result?.comments ?? [];
 
   return (
     <div className="flex flex-col gap-3">
-      <CommentInput responseId={responseId} />
+      <CommentInput
+        responseId={responseId}
+        initialContent={draft}
+        onContentChange={onDraftChange}
+      />
 
       {isLoading && <p className="text-caption-4 text-grey-400">댓글 불러오는 중...</p>}
 

--- a/src/features/retrospective/ui/detail/MemberResponseColumns.tsx
+++ b/src/features/retrospective/ui/detail/MemberResponseColumns.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { ResponseCard } from './ResponseCard';
 import type {
   BaseApiResponse,
@@ -16,6 +17,17 @@ export function MemberResponseColumns({
   queryResults,
   memberName,
 }: MemberResponseColumnsProps) {
+  const [openCommentId, setOpenCommentId] = useState<number | null>(null);
+  const draftMapRef = useRef<Map<number, string>>(new Map());
+
+  const handleToggleComment = (responseId: number) => {
+    setOpenCommentId((prev) => (prev === responseId ? null : responseId));
+  };
+
+  const handleDraftChange = (responseId: number, content: string) => {
+    draftMapRef.current.set(responseId, content);
+  };
+
   return (
     <div className="flex gap-5">
       {questions.map((question, idx) => {
@@ -29,7 +41,16 @@ export function MemberResponseColumns({
               {idx + 1}. {question.content}
             </h3>
             <div className="mt-3">
-              {memberResponse && <ResponseCard response={memberResponse} hideAuthor />}
+              {memberResponse && (
+                <ResponseCard
+                  response={memberResponse}
+                  hideAuthor
+                  openCommentId={openCommentId}
+                  onToggleComment={handleToggleComment}
+                  draft={draftMapRef.current.get(memberResponse.responseId) ?? ''}
+                  onDraftChange={handleDraftChange}
+                />
+              )}
             </div>
           </div>
         );

--- a/src/features/retrospective/ui/detail/MemberSubTabs.tsx
+++ b/src/features/retrospective/ui/detail/MemberSubTabs.tsx
@@ -15,14 +15,14 @@ export function MemberSubTabs({ members, selectedMemberId, onSelect }: MemberSub
           key={member.memberId}
           type="button"
           className={cn(
-            'cursor-pointer rounded-[8px] px-[25px] py-[8.5px] text-center text-sub-title-4 transition-colors',
+            'w-full cursor-pointer overflow-hidden rounded-[8px] px-2 py-[8.5px] text-center text-sub-title-4 transition-colors',
             selectedMemberId === member.memberId
               ? 'bg-blue-200 text-blue-500'
               : 'bg-grey-100 text-grey-900'
           )}
           onClick={() => onSelect(member.memberId)}
         >
-          <span className="truncate">{member.userName}</span>
+          <span className="block truncate">{member.userName}</span>
         </button>
       ))}
     </nav>

--- a/src/features/retrospective/ui/detail/QuestionTabContent.tsx
+++ b/src/features/retrospective/ui/detail/QuestionTabContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ResponseCard } from './ResponseCard';
 import { useResponses } from '../../api/retrospective.queries';
 import { QUESTION_CATEGORIES } from '../../model/constants';
@@ -12,6 +12,16 @@ interface QuestionTabContentProps {
 
 export function QuestionTabContent({ retrospectId, questions }: QuestionTabContentProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [openCommentId, setOpenCommentId] = useState<number | null>(null);
+  const draftMapRef = useRef<Map<number, string>>(new Map());
+
+  const handleToggleComment = (responseId: number) => {
+    setOpenCommentId((prev) => (prev === responseId ? null : responseId));
+  };
+
+  const handleDraftChange = (responseId: number, content: string) => {
+    draftMapRef.current.set(responseId, content);
+  };
   const selectedCategory = QUESTION_CATEGORIES[selectedIndex] as ResponseCategory;
 
   const selectedQuestion = questions[selectedIndex];
@@ -50,7 +60,14 @@ export function QuestionTabContent({ retrospectId, questions }: QuestionTabConte
 
           <div className="mt-4 flex flex-col">
             {responses.map((response) => (
-              <ResponseCard key={response.responseId} response={response} />
+              <ResponseCard
+                key={response.responseId}
+                response={response}
+                openCommentId={openCommentId}
+                onToggleComment={handleToggleComment}
+                draft={draftMapRef.current.get(response.responseId) ?? ''}
+                onDraftChange={handleDraftChange}
+              />
             ))}
           </div>
         </div>

--- a/src/features/retrospective/ui/detail/ResponseCard.tsx
+++ b/src/features/retrospective/ui/detail/ResponseCard.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { CommentButton } from './CommentButton';
 import { CommentSection } from './CommentSection';
 import { LikeButton } from './LikeButton';
@@ -9,10 +8,21 @@ import { Avatar } from '@/shared/ui/avatar/Avatar';
 interface ResponseCardProps {
   response: ResponseListItem;
   hideAuthor?: boolean;
+  openCommentId: number | null;
+  onToggleComment: (responseId: number) => void;
+  draft: string;
+  onDraftChange: (responseId: number, content: string) => void;
 }
 
-export function ResponseCard({ response, hideAuthor = false }: ResponseCardProps) {
-  const [showComments, setShowComments] = useState(false);
+export function ResponseCard({
+  response,
+  hideAuthor = false,
+  openCommentId,
+  onToggleComment,
+  draft,
+  onDraftChange,
+}: ResponseCardProps) {
+  const showComments = openCommentId === response.responseId;
 
   return (
     <div className={hideAuthor ? 'py-4' : 'border-b border-grey-100 py-4 last:border-b-0'}>
@@ -41,11 +51,17 @@ export function ResponseCard({ response, hideAuthor = false }: ResponseCardProps
               />
               <CommentButton
                 commentCount={response.commentCount}
-                onClick={() => setShowComments((prev) => !prev)}
+                onClick={() => onToggleComment(response.responseId)}
               />
             </div>
 
-            {showComments && <CommentSection responseId={response.responseId} />}
+            {showComments && (
+              <CommentSection
+                responseId={response.responseId}
+                draft={draft}
+                onDraftChange={(content) => onDraftChange(response.responseId, content)}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/features/team/ui/JoinTeamDialog.tsx
+++ b/src/features/team/ui/JoinTeamDialog.tsx
@@ -19,7 +19,7 @@ export function JoinTeamDialog({ open, onOpenChange }: JoinTeamDialogProps) {
       <DialogPortal>
         <DialogOverlay className="bg-black/50" />
         <DialogContent className="w-[400px] bg-white rounded-[12px] p-[20px]" disableOutsideClick>
-          <DialogHeader>
+          <DialogHeader className="mb-4">
             <DialogTitle className="text-xl font-bold">팀 참여하기</DialogTitle>
           </DialogHeader>
 

--- a/src/features/team/ui/NoTeamEmptyState.tsx
+++ b/src/features/team/ui/NoTeamEmptyState.tsx
@@ -20,11 +20,20 @@ export function NoTeamEmptyState() {
           </p>
 
           <div className="flex items-center gap-2">
-            <Button size="lg" onClick={() => setIsCreateOpen(true)} className="gap-1">
+            <Button
+              size="lg"
+              onClick={() => setIsCreateOpen(true)}
+              className="gap-1 px-[10px] py-2"
+            >
               <IcPlus className="w-3 h-3" /> 팀 생성하기
             </Button>
-            <Button size="lg" variant="secondary" onClick={() => setIsJoinOpen(true)}>
-              팀 참여하기
+            <Button
+              size="lg"
+              variant="secondary"
+              onClick={() => setIsJoinOpen(true)}
+              className="px-[10px] py-2"
+            >
+              기존 팀 참여하기
             </Button>
           </div>
         </div>

--- a/src/pages/retrospective-write/ui/SubmitSuccessModal.tsx
+++ b/src/pages/retrospective-write/ui/SubmitSuccessModal.tsx
@@ -17,10 +17,7 @@ export function SubmitSuccessModal({ open, onClose, onConfirm }: SubmitSuccessMo
     <DialogRoot open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogPortal>
         <DialogOverlay className="bg-black/50" />
-        <DialogContent
-          hideCloseButton
-          className="w-[434px] rounded-2xl bg-white px-[20px] py-[28px] shadow-xl"
-        >
+        <DialogContent hideCloseButton className="w-[300px] rounded-2xl bg-white p-5 shadow-xl">
           <div className="flex flex-col items-center">
             <IcCheckBlueBgLightblue width={48} height={48} />
 
@@ -29,18 +26,18 @@ export function SubmitSuccessModal({ open, onClose, onConfirm }: SubmitSuccessMo
               <p className="text-caption-4 text-grey-800">팀원들의 회고 내용을 확인할까요?</p>
             </div>
 
-            <div className="mt-7 flex gap-2">
+            <div className="mt-7 flex w-full justify-end gap-2">
               <Button
                 variant="tertiary"
                 onClick={onClose}
-                className="h-[48px] rounded-[12px] px-[28px] text-sub-title-3"
+                className="rounded-[8px] px-[10px] py-[8px] text-sub-title-4 leading-[140%]"
               >
                 닫기
               </Button>
               <Button
                 variant="primary"
                 onClick={onConfirm}
-                className="h-[48px] rounded-[12px] px-[28px] text-sub-title-3"
+                className="rounded-[8px] px-[10px] py-[8px] text-sub-title-4 leading-[140%]"
               >
                 확인하기
               </Button>


### PR DESCRIPTION
## 요약

- 완료된 회고 팀원 탭 이름 태그 truncate 처리
- 회고 제출 완료 모달 UI 스타일 수정
- 댓글 입력 키보드 단축키 제거 및 댓글창 단일 활성화 + 드래프트 보존
- 팀 없음 화면 버튼 스타일/텍스트 수정 및 팀 참여 모달 헤더 갭 추가

## 변경 사항

- **MemberSubTabs**: `button`에 `w-full overflow-hidden`, `span`에 `block` 추가 → 이름 truncate 정상 동작 (84px / px-2 기준)
- **SubmitSuccessModal**: 너비 `300px`, `p-5`, 버튼 우측 정렬 / `text-sub-title-4` / `px-[10px] py-[8px]` / `leading-[140%]` / `rounded-[8px]`
- **CommentInput**: Ctrl+Enter / Shift+Enter 제출 핸들러 제거, 남기기 버튼으로만 제출
- **QuestionTabContent, MemberResponseColumns**: `openCommentId`로 댓글창 단일 활성화 / `draftMapRef`로 작성 중 내용 보존 (새로고침 전까지 복원)
- **ResponseCard, CommentSection, CommentInput**: draft / onDraftChange prop 체인 연결
- **NoTeamEmptyState**: 버튼 `px-[10px] py-2` / "팀 참여하기" → "기존 팀 참여하기"
- **JoinTeamDialog**: `DialogHeader`에 `mb-4` 추가로 헤더-라벨 간격 확보

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인

Closes #161