### PR TITLE
[#163] Bug: 회고 분석 탭 플로우 설계 개선 - status 기반 제출 인원 계산 및 에러 처리

### DIFF
--- a/src/features/retrospective/api/retrospective.mutations.ts
+++ b/src/features/retrospective/api/retrospective.mutations.ts
@@ -20,6 +20,7 @@ import type {
   SubmitRetrospectRequest,
 } from '../model/types';
 import { ApiError } from '@/shared/api/error';
+import { toastStore } from '@/shared/ui/toast/Toast';
 
 export function useCreateRetrospect(retroRoomId: number) {
   const queryClient = useQueryClient();
@@ -112,7 +113,10 @@ export function useAnalyzeRetrospective(retrospectId: number) {
     onError: (error) => {
       if (error instanceof ApiError && error.status === 409) {
         queryClient.refetchQueries({ queryKey: retrospectiveQueryKeys.analysis(retrospectId) });
+        return;
       }
+      const message = error instanceof ApiError ? error.message : '알 수 없는 오류가 발생했습니다';
+      toastStore.getState().addToast({ variant: 'warning', message });
     },
     meta: { skipGlobalError: true },
   });

--- a/src/features/retrospective/model/types.ts
+++ b/src/features/retrospective/model/types.ts
@@ -107,6 +107,7 @@ export interface RetrospectQuestionItem {
 export interface RetrospectMemberItem {
   memberId: number;
   userName: string;
+  status: 'IN_PROGRESS' | 'DRAFT' | 'SUBMITTED';
 }
 
 export interface RetrospectDetailResponse {

--- a/src/features/retrospective/ui/detail/AnalysisResult.tsx
+++ b/src/features/retrospective/ui/detail/AnalysisResult.tsx
@@ -34,7 +34,7 @@ export function AnalysisResult({ analysis }: AnalysisResultProps) {
   const currentUser = analysis.personalMissions[0];
 
   return (
-    <div className="flex flex-col gap-[68px] py-8">
+    <div className="flex flex-col gap-[68px]">
       {/* AI 인사이트 */}
       {analysis.insight && (
         <section>

--- a/src/features/retrospective/ui/detail/AnalysisTabContent.tsx
+++ b/src/features/retrospective/ui/detail/AnalysisTabContent.tsx
@@ -13,8 +13,10 @@ export function AnalysisTabContent({
   participantCount,
   totalParticipants,
 }: AnalysisTabContentProps) {
-  const { data } = useAnalysisResult(retrospectId);
+  const { data, isPending } = useAnalysisResult(retrospectId);
   const analysis = data?.result;
+
+  if (isPending) return null;
 
   if (!analysis || (!analysis.emotionRank.length && !analysis.insight)) {
     return (
@@ -27,7 +29,7 @@ export function AnalysisTabContent({
   }
 
   return (
-    <div className="px-6">
+    <div className="px-10 py-8">
       <AnalysisResult analysis={analysis} />
     </div>
   );

--- a/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
+++ b/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
@@ -45,7 +45,7 @@ function DetailContent({ retrospectId, teamId }: { retrospectId: number; teamId:
             {activeTab === 'analysis' && (
               <AnalysisTabContent
                 retrospectId={retrospectId}
-                participantCount={detail.members.length}
+                participantCount={detail.members.filter((m) => m.status === 'SUBMITTED').length}
                 totalParticipants={detail.members.length}
               />
             )}


### PR DESCRIPTION
## 요약

- `RetrospectMemberItem` 타입에 `status` 필드 누락으로 인한 제출 인원 계산 버그 수정
- `participantCount`가 전체 멤버 수로 잘못 계산되던 문제 수정 (SUBMITTED 멤버 수로 변경)
- 분석 실행 에러 처리 개선: 409는 리페치, 그 외 에러는 서버 메시지 토스트 표시
- 분석 탭 진입 시 `isPending` 동안 empty state가 선노출되던 문제 수정

## 변경 사항

- `src/features/retrospective/model/types.ts` — `RetrospectMemberItem`에 `status: 'IN_PROGRESS' | 'DRAFT' | 'SUBMITTED'` 추가
- `src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx` — `participantCount`를 `members.filter(m => m.status === 'SUBMITTED').length`로 수정
- `src/features/retrospective/api/retrospective.mutations.ts` — `useAnalyzeRetrospective` 에러 처리 개선 (409 리페치 / 그 외 토스트)
- `src/features/retrospective/ui/detail/AnalysisTabContent.tsx` — `isPending` 중 `null` 반환으로 empty state 선노출 방지, 패딩 `px-10 py-8` 적용
- `src/features/retrospective/ui/detail/AnalysisResult.tsx` — 컨테이너 `py` 제거

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인