### PR TITLE
[#178] Feature: 답변 제출 시점(submittedAt) 기반 상대 시간 표시

### DIFF
--- a/src/features/retrospective/lib/date.ts
+++ b/src/features/retrospective/lib/date.ts
@@ -1,9 +1,4 @@
-import {
-  differenceInCalendarDays,
-  differenceInHours,
-  differenceInMinutes,
-  startOfDay,
-} from 'date-fns';
+import { differenceInCalendarDays, differenceInMinutes, startOfDay } from 'date-fns';
 
 /**
  * 회고 날짜를 기준으로 D-day 라벨을 반환한다.
@@ -25,14 +20,8 @@ export function formatRelativeTime(dateString?: string): string {
   const target = new Date(dateString);
   const mins = differenceInMinutes(now, target);
 
-  if (mins < 1) return '방금 전';
-  if (mins < 60) return `${mins}분전`;
-
-  const hours = differenceInHours(now, target);
-  if (hours < 24) return `${hours}시간전`;
+  if (mins < 1440) return `${Math.max(mins, 1)}분전`;
 
   const days = differenceInCalendarDays(now, target);
-  if (days < 30) return `${days}일 후`;
-
-  return target.toLocaleDateString('ko-KR');
+  return `${days}일 후`;
 }

--- a/src/features/retrospective/model/types.ts
+++ b/src/features/retrospective/model/types.ts
@@ -132,6 +132,7 @@ export interface ResponseListItem {
   commentCount: number;
   content: string;
   createdAt?: string;
+  submittedAt?: string;
   isLiked?: boolean;
   likeCount: number;
   responseId: number;

--- a/src/features/retrospective/ui/detail/ResponseCard.tsx
+++ b/src/features/retrospective/ui/detail/ResponseCard.tsx
@@ -33,9 +33,9 @@ export function ResponseCard({
             {!hideAuthor && (
               <span className="text-sub-title-4 text-grey-900">{response.userName}</span>
             )}
-            {!hideAuthor && response.createdAt && (
+            {!hideAuthor && response.submittedAt && (
               <span className="text-caption-6 text-grey-700">
-                {formatRelativeTime(response.createdAt)}
+                {formatRelativeTime(response.submittedAt)}
               </span>
             )}
             <p className="whitespace-pre-wrap break-all text-long-2 text-grey-900">


### PR DESCRIPTION
## Summary

- `ResponseListItem`에 `submittedAt?: string` 필드 추가
- `formatRelativeTime` 로직 정리: 24h 이내 `n분전`, 이후 `n일 후`
- `ResponseCard`에서 `createdAt` → `submittedAt` 기준으로 시간 표시

## Test plan

- [ ] 답변 제출 후 24시간 이내: `n분전` 표시 확인
- [ ] 답변 제출 후 24시간 이후: `n일 후` 표시 확인
- [ ] `submittedAt`이 없는 경우 시간 미표시 확인

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)