### PR TITLE
[#185] Chore: 긴급 QA

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -21,14 +21,16 @@ function App() {
         {/* OAuth 콜백 - 가드 바깥 */}
         <Route path="/callback" element={<CallbackPage />} />
 
+        {/* 온보딩: RouteGuard 바깥 (신규/탈퇴 후 재가입 유저는 세션 없음) */}
+        <Route element={<OnboardingRoute />}>
+          <Route path="/onboarding" element={<OnboardingPage />} />
+        </Route>
+
         {/* 인증 확인 게이트 */}
         <Route element={<RouteGuard />}>
           {/* Public: 비로그인 유저만 */}
           <Route element={<PublicRoute />}>
             <Route path="/signin" element={<SigninPage />} />
-            <Route element={<OnboardingRoute />}>
-              <Route path="/onboarding" element={<OnboardingPage />} />
-            </Route>
           </Route>
 
           {/* Private: 로그인 유저만 */}

--- a/src/features/auth/ui/forms/SigninForm.tsx
+++ b/src/features/auth/ui/forms/SigninForm.tsx
@@ -18,7 +18,7 @@ export function SigninForm() {
       </div>
 
       {/* 소셜 로그인 버튼 그룹 */}
-      <div className="mt-[90px] flex flex-col gap-3">
+      <div className="mt-[clamp(24px,8vh,90px)] flex flex-col gap-3">
         <KakaoOAuthButton />
         <GoogleOAuthButton />
       </div>

--- a/src/features/auth/ui/routes/PublicRoute.tsx
+++ b/src/features/auth/ui/routes/PublicRoute.tsx
@@ -4,7 +4,9 @@ import { useProfile } from '../../api/auth.queries';
 export function PublicRoute() {
   const { data } = useProfile();
 
-  if (data?.isSuccess) {
+  // 닉네임이 설정된 기존 회원만 홈으로 리다이렉트
+  // 신규 회원(nickname null)은 온보딩을 통과할 수 있도록 허용
+  if (data?.isSuccess && data.result.nickname) {
     return <Navigate to="/" replace />;
   }
 

--- a/src/features/auth/ui/steps/NicknameStep.tsx
+++ b/src/features/auth/ui/steps/NicknameStep.tsx
@@ -47,7 +47,12 @@ export function NicknameStep() {
       </Field>
 
       <div className="mt-[clamp(24px,calc(100dvh-700px),260px)] flex justify-end">
-        <Button onClick={goToNextStep} disabled={!nickname?.trim()} size="md">
+        <Button
+          onClick={goToNextStep}
+          disabled={!nickname?.trim()}
+          size="md"
+          className="text-sub-title-5"
+        >
           다음
         </Button>
       </div>

--- a/src/features/auth/ui/steps/TeamActionStep.tsx
+++ b/src/features/auth/ui/steps/TeamActionStep.tsx
@@ -52,7 +52,7 @@ export function TeamActionStep() {
         </Field>
 
         <div className="mt-[clamp(24px,calc(100dvh-700px),260px)] flex justify-end">
-          <Button type="submit" disabled={!teamName?.trim()} size="md">
+          <Button type="submit" disabled={!teamName?.trim()} size="md" className="text-sub-title-5">
             다음
           </Button>
         </div>
@@ -90,7 +90,12 @@ export function TeamActionStep() {
         </Field>
 
         <div className="mt-[clamp(24px,calc(100dvh-700px),260px)] flex justify-end">
-          <Button type="submit" disabled={!inviteLink?.trim() || !!errors.inviteLink} size="md">
+          <Button
+            type="submit"
+            disabled={!inviteLink?.trim() || !!errors.inviteLink}
+            size="md"
+            className="text-sub-title-5"
+          >
             다음
           </Button>
         </div>

--- a/src/features/auth/ui/steps/TeamStep.tsx
+++ b/src/features/auth/ui/steps/TeamStep.tsx
@@ -74,7 +74,12 @@ export function TeamStep() {
       />
 
       <div className="mt-[clamp(24px,calc(100dvh-700px),260px)] flex justify-end">
-        <Button onClick={goToNextStep} disabled={!teamOption} size="md">
+        <Button
+          onClick={goToNextStep}
+          disabled={!teamOption}
+          size="md"
+          className="text-sub-title-5"
+        >
           다음
         </Button>
       </div>

--- a/src/features/retrospective/api/retrospective.queries.ts
+++ b/src/features/retrospective/api/retrospective.queries.ts
@@ -1,7 +1,8 @@
 import {
+  keepPreviousData,
+  useQueries,
   useQuery,
   useQueryClient,
-  useSuspenseQueries,
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import {
@@ -71,10 +72,11 @@ export function useReferences(retrospectId: number) {
 }
 
 export function useResponses(retrospectId: number, category: ResponseCategory) {
-  return useSuspenseQuery({
+  return useQuery({
     queryKey: retrospectiveQueryKeys.responses(retrospectId, category),
     queryFn: () => listResponses(retrospectId, { category, size: 100 }),
     staleTime: 1000 * 60 * 2,
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -100,11 +102,12 @@ export function useAnalysisResult(retrospectId: number) {
 }
 
 export function useQuestionResponses(retrospectId: number, questionCategories: ResponseCategory[]) {
-  return useSuspenseQueries({
+  return useQueries({
     queries: questionCategories.map((category) => ({
       queryKey: retrospectiveQueryKeys.responses(retrospectId, category),
       queryFn: () => listResponses(retrospectId, { category, size: 100 }),
       staleTime: 1000 * 60 * 2,
+      placeholderData: keepPreviousData,
     })),
   });
 }

--- a/src/features/retrospective/ui/RetrospectCard.tsx
+++ b/src/features/retrospective/ui/RetrospectCard.tsx
@@ -119,12 +119,12 @@ function CardInfo({
 }) {
   return (
     <div className={`${className} flex flex-col gap-[3px]`}>
-      <div className="flex items-center gap-3">
-        <span className="text-sub-title-6 text-grey-700">회고 방식</span>
+      <div className="flex items-center">
+        <span className="w-[52px] shrink-0 text-sub-title-6 text-grey-700">회고 방식</span>
         <span className="text-sub-title-6 text-grey-800">{methodLabel}</span>
       </div>
-      <div className="flex items-center gap-3">
-        <span className="text-sub-title-6 text-grey-700">날짜</span>
+      <div className="flex items-center">
+        <span className="w-[52px] shrink-0 text-sub-title-6 text-grey-700">날짜</span>
         <span className="text-sub-title-6 text-grey-800">{formattedDate}</span>
       </div>
     </div>
@@ -190,8 +190,8 @@ function ActiveCard({ item, teamId }: RetrospectCardProps) {
           <CardInfo methodLabel={methodLabel} formattedDate={formattedDate} className="" />
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: stop propagation for dropdown */}
           {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation wrapper */}
-          <div className="flex items-center gap-3" onClick={(e) => e.stopPropagation()}>
-            <span className="text-sub-title-6 text-grey-700">참여인원</span>
+          <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
+            <span className="w-[52px] shrink-0 text-sub-title-6 text-grey-700">참여인원</span>
             <ParticipantDropdown
               retrospectId={item.retrospectId}
               participantCount={item.participantCount}
@@ -263,16 +263,18 @@ function CompletedCard({ item, teamId }: RetrospectCardProps) {
       className="flex w-[284px] flex-col rounded-xl bg-white p-[18px] cursor-pointer text-left"
       onClick={() => navigate(`/teams/${teamId}/retrospects/${item.retrospectId}`)}
     >
-      {dDayLabel && (
-        <span className="mb-[6px] flex items-center self-start rounded-[4px] bg-grey-100 px-[10.5px] py-[4px] text-sub-title-5 text-grey-800">
-          {dDayLabel}
-        </span>
-      )}
-      <div className="flex items-center justify-between">
-        <span className="truncate text-title-4 text-black">{item.projectName}</span>
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col">
+          {dDayLabel && (
+            <span className="mb-[6px] flex items-center self-start rounded-[4px] bg-grey-100 px-[10.5px] py-[4px] text-sub-title-5 text-grey-800">
+              {dDayLabel}
+            </span>
+          )}
+          <span className="truncate text-title-4 text-black">{item.projectName}</span>
+        </div>
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: stop propagation for menu */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation wrapper */}
-        <div onClick={(e) => e.stopPropagation()}>
+        <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
           <CardMenu
             title={item.projectName}
             retrospectId={item.retrospectId}
@@ -281,12 +283,12 @@ function CompletedCard({ item, teamId }: RetrospectCardProps) {
           />
         </div>
       </div>
-      <div className="mt-4 flex flex-col gap-[3px]">
+      <div className={`${dDayLabel ? 'mt-3' : 'mt-4'} flex flex-col gap-[3px]`}>
         <CardInfo methodLabel={methodLabel} formattedDate={formattedDate} className="" />
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: stop propagation for dropdown */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: stop propagation wrapper */}
-        <div className="flex items-center gap-3" onClick={(e) => e.stopPropagation()}>
-          <span className="text-sub-title-6 text-grey-700">참여인원</span>
+        <div className="flex items-center" onClick={(e) => e.stopPropagation()}>
+          <span className="w-[52px] shrink-0 text-sub-title-6 text-grey-700">참여인원</span>
           <ParticipantDropdown
             retrospectId={item.retrospectId}
             participantCount={item.participantCount}

--- a/src/features/retrospective/ui/RetrospectColumn.tsx
+++ b/src/features/retrospective/ui/RetrospectColumn.tsx
@@ -49,7 +49,7 @@ export function RetrospectColumn({ title, items, teamId }: RetrospectColumnProps
   };
 
   return (
-    <div className="flex flex-1 flex-col min-h-0">
+    <div className="flex w-[284px] shrink-0 flex-col min-h-0">
       <div className="mb-3 flex items-center gap-1.5">
         <span className="text-caption-2 text-grey-900">{title}</span>
         <span className="text-caption-2 text-grey-900">{items.length}</span>

--- a/src/features/retrospective/ui/detail/MemberResponseColumns.tsx
+++ b/src/features/retrospective/ui/detail/MemberResponseColumns.tsx
@@ -8,7 +8,7 @@ import type {
 
 interface MemberResponseColumnsProps {
   questions: RetrospectQuestionItem[];
-  queryResults: { data: BaseApiResponse<ResponsesListResponse> }[];
+  queryResults: { data: BaseApiResponse<ResponsesListResponse> | undefined }[];
   memberName: string;
 }
 
@@ -29,10 +29,10 @@ export function MemberResponseColumns({
   };
 
   return (
-    <div className="flex gap-5">
+    <div className="flex gap-8">
       {questions.map((question, idx) => {
         const result = queryResults[idx];
-        const responses = result.data.result?.responses ?? [];
+        const responses = result.data?.result?.responses ?? [];
         const memberResponse = responses.find((r) => r.userName === memberName);
 
         return (

--- a/src/features/retrospective/ui/detail/MemberTabContent.tsx
+++ b/src/features/retrospective/ui/detail/MemberTabContent.tsx
@@ -28,14 +28,14 @@ export function MemberTabContent({ retrospectId, members, questions }: MemberTab
   const selectedMember = members.find((m) => m.memberId === selectedMemberId);
 
   return (
-    <div className="flex h-full gap-[42px] pt-6 pb-2 pl-6 pr-2">
+    <div className="flex gap-[42px] pt-6 pb-2 pl-6 pr-2">
       <MemberSubTabs
         members={members}
         selectedMemberId={selectedMemberId}
         onSelect={setSelectedMemberId}
       />
 
-      <div className="min-w-0 mt-6 flex-1 overflow-x-auto [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-grey-300">
+      <div className="min-w-0 mt-6 flex-1 overflow-x-auto [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:h-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-grey-300 pb-12">
         {selectedMember && (
           <MemberResponseColumns
             questions={questions}

--- a/src/features/retrospective/ui/detail/QuestionTabContent.tsx
+++ b/src/features/retrospective/ui/detail/QuestionTabContent.tsx
@@ -29,7 +29,7 @@ export function QuestionTabContent({ retrospectId, questions }: QuestionTabConte
   const responses = data?.result?.responses ?? [];
 
   return (
-    <div className="flex h-full gap-[42px] py-6 pl-6 pr-2">
+    <div className="flex gap-[42px] py-6 pl-6 pr-2 pb-12">
       <nav className="flex w-[84px] shrink-0 flex-col gap-3">
         {questions.map((q, idx) => (
           <button
@@ -46,7 +46,7 @@ export function QuestionTabContent({ retrospectId, questions }: QuestionTabConte
         ))}
       </nav>
 
-      <div className="min-h-0 mt-6 flex-1 overflow-auto [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-grey-300">
+      <div className="mt-6 flex-1">
         <div className="max-w-[840px]">
           {selectedQuestion && (
             <h2 className="text-title-3 text-grey-1000">{selectedQuestion.content}</h2>

--- a/src/features/retrospective/ui/steps/DateTimeStep.tsx
+++ b/src/features/retrospective/ui/steps/DateTimeStep.tsx
@@ -67,7 +67,7 @@ export function DateTimeStep({ onClose }: DateTimeStepProps) {
           size="lg"
           onClick={goToNextStep}
           disabled={!isValid}
-          className="h-[32px] px-[18.5px] py-[7px]"
+          className="h-[32px] px-[18.5px] py-[7px] text-sub-title-4"
         >
           다음
         </Button>

--- a/src/features/retrospective/ui/steps/MethodStep.tsx
+++ b/src/features/retrospective/ui/steps/MethodStep.tsx
@@ -77,7 +77,7 @@ export function MethodStep({ onClose }: MethodStepProps) {
           size="lg"
           onClick={goToNextStep}
           disabled={!retrospectMethod}
-          className="h-[32px] px-[18.5px] py-[7px]"
+          className="h-[32px] px-[18.5px] py-[7px] text-sub-title-4"
         >
           다음
         </Button>

--- a/src/features/retrospective/ui/steps/ProjectNameStep.tsx
+++ b/src/features/retrospective/ui/steps/ProjectNameStep.tsx
@@ -59,7 +59,7 @@ export function ProjectNameStep({ onClose }: ProjectNameStepProps) {
           variant="primary"
           onClick={goToNextStep}
           disabled={!projectName?.trim()}
-          className="h-[32px] px-[18.5px] py-[7px]"
+          className="h-[32px] px-[18.5px] py-[7px] text-sub-title-4"
         >
           다음
         </Button>

--- a/src/features/retrospective/ui/steps/ReferenceStep.tsx
+++ b/src/features/retrospective/ui/steps/ReferenceStep.tsx
@@ -102,7 +102,7 @@ export function ReferenceStep({ onClose }: ReferenceStepProps) {
           size="md"
           disabled={!choice || isSubmitting}
           onClick={handleConfirmClick}
-          className="h-[32px] px-[18.5px] py-[7px]"
+          className="h-[32px] px-[18.5px] py-[7px] text-sub-title-5"
         >
           {choice === 'no' ? '완료' : '다음'}
         </Button>

--- a/src/features/retrospective/ui/steps/ReferenceUrlStep.tsx
+++ b/src/features/retrospective/ui/steps/ReferenceUrlStep.tsx
@@ -149,7 +149,7 @@ export function ReferenceUrlStep({ onClose, onBack }: ReferenceUrlStepProps) {
           size="md"
           disabled={!hasValidUrl || isSubmitting}
           onClick={handleConfirmClick}
-          className="h-[32px] px-[18.5px] py-[7px]"
+          className="h-[32px] px-[18.5px] py-[7px] text-sub-title-5"
         >
           확인
         </Button>

--- a/src/features/retrospective/ui/steps/StepIndicator.tsx
+++ b/src/features/retrospective/ui/steps/StepIndicator.tsx
@@ -4,9 +4,9 @@ export function StepIndicator() {
   const { currentStep, totalSteps } = useStepContext();
 
   return (
-    <span className="text-body-2 mb-1">
+    <div className="text-body-2 mb-1">
       <span className="text-blue-500">{currentStep + 1}</span>
       <span className="text-grey-700">/{totalSteps}</span>
-    </span>
+    </div>
   );
 }

--- a/src/features/team/ui/JoinTeamForm.tsx
+++ b/src/features/team/ui/JoinTeamForm.tsx
@@ -55,7 +55,12 @@ export function JoinTeamForm({ onSuccess, onClose }: JoinTeamFormProps) {
       </Field>
 
       <div className="flex justify-end">
-        <Button type="submit" disabled={!inviteUrl?.trim()} size="md" className="px-3 py-2">
+        <Button
+          type="submit"
+          disabled={!inviteUrl?.trim()}
+          size="md"
+          className="px-3 py-2 text-sub-title-5"
+        >
           확인
         </Button>
       </div>

--- a/src/features/team/ui/TeamNameStep.tsx
+++ b/src/features/team/ui/TeamNameStep.tsx
@@ -47,7 +47,7 @@ export function TeamNameStep() {
       </div>
 
       <div className="flex justify-end">
-        <Button type="submit" size="md" className="px-3 py-2">
+        <Button type="submit" size="md" className="px-3 py-2 text-sub-title-5">
           만들기
         </Button>
       </div>

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -9,9 +9,9 @@ export function OnboardingPage() {
   return (
     <div className="h-screen bg-grey-50 flex flex-col">
       <OnboardingHeader />
-      <main className="flex-1 overflow-y-auto">
-        <div className="flex min-h-full flex-col items-center py-4">
-          <div className="my-auto w-[720px] bg-white rounded-2xl flex items-center justify-center py-[130px]">
+      <main className="flex-1 flex flex-col overflow-y-auto">
+        <div className="flex-1 flex flex-col items-center py-4">
+          <div className="flex-1 w-[720px] bg-white rounded-2xl flex items-center justify-center">
             <OnboardingForm
               onCreateTeam={(title) => createRetroRoom({ title })}
               onJoinTeam={(inviteUrl) => joinRetroRoom({ inviteUrl })}

--- a/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
+++ b/src/pages/retrospective-detail/ui/RetrospectiveDetailPage.tsx
@@ -6,7 +6,6 @@ import { AnalysisTabContent } from '@/features/retrospective/ui/detail/AnalysisT
 import { DetailHeader } from '@/features/retrospective/ui/detail/DetailHeader';
 import { MemberTabContent } from '@/features/retrospective/ui/detail/MemberTabContent';
 import { QuestionTabContent } from '@/features/retrospective/ui/detail/QuestionTabContent';
-import { cn } from '@/shared/lib/cn';
 import { ApiErrorBoundary } from '@/shared/ui/error-boundary/ApiErrorBoundary';
 import { RetrospectivePageHeader } from '@/widgets/header/ui/RetrospectivePageHeader';
 
@@ -17,22 +16,12 @@ function DetailContent({ retrospectId, teamId }: { retrospectId: number; teamId:
   const detail = data.result;
 
   return (
-    <>
+    <div className="flex flex-col">
       <RetrospectivePageHeader teamId={teamId} title={detail.title} />
-      <div className="flex h-[calc(100vh-54px)] flex-col overflow-auto bg-grey-50">
-        <div
-          className={cn(
-            'mx-auto flex w-full max-w-[1096px] flex-col',
-            activeTab !== 'analysis' && 'min-h-0 flex-1'
-          )}
-        >
+      <div className="flex flex-col bg-grey-50 min-h-[calc(100vh-54px)] pb-12">
+        <div className="mx-auto flex w-full max-w-[1096px] flex-1 flex-col">
           <DetailHeader activeTab={activeTab} onTabChange={setActiveTab} title={detail.title} />
-          <div
-            className={cn(
-              'flex min-h-0 flex-col rounded-t-[20px] bg-white',
-              activeTab === 'analysis' ? 'mb-12 rounded-b-[20px]' : 'flex-1 overflow-hidden'
-            )}
-          >
+          <div className="mt-4 flex flex-1 flex-col rounded-[20px] bg-white">
             {activeTab === 'question' && (
               <Suspense fallback={null}>
                 <QuestionTabContent retrospectId={retrospectId} questions={detail.questions} />
@@ -57,7 +46,7 @@ function DetailContent({ retrospectId, teamId }: { retrospectId: number; teamId:
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }
 
@@ -68,7 +57,7 @@ export function RetrospectiveDetailPage() {
   const numRetrospectId = Number(retrospectId);
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="flex min-h-screen flex-col bg-white">
       <ApiErrorBoundary resetKeys={[numRetrospectId]}>
         <Suspense
           fallback={

--- a/src/pages/retrospective-write/ui/WriteContent.tsx
+++ b/src/pages/retrospective-write/ui/WriteContent.tsx
@@ -94,7 +94,7 @@ function AssistantSection({
       <button
         type="button"
         onClick={onGenerate}
-        className="mt-3 flex cursor-pointer items-center gap-2 text-grey-500"
+        className="mt-3 flex cursor-pointer items-center gap-2 rounded-[4px] px-2 py-1 text-grey-500 hover:bg-grey-100"
       >
         <IcRefresh width={12} height={12} />
         <span className="text-sub-title-6">다시 생성</span>

--- a/src/pages/signin/ui/SigninPage.tsx
+++ b/src/pages/signin/ui/SigninPage.tsx
@@ -7,7 +7,7 @@ export function SigninPage() {
       <OnboardingHeader />
       <main className="flex-1 flex flex-col overflow-y-auto">
         <div className="flex-1 flex flex-col items-center py-4">
-          <div className="flex-1 w-[720px] bg-white rounded-2xl flex items-center justify-center">
+          <div className="flex-1 w-full max-w-[720px] bg-white rounded-2xl flex items-center justify-center">
             <SigninForm />
           </div>
         </div>

--- a/src/pages/signin/ui/SigninPage.tsx
+++ b/src/pages/signin/ui/SigninPage.tsx
@@ -5,9 +5,9 @@ export function SigninPage() {
   return (
     <div className="h-screen bg-grey-50 flex flex-col">
       <OnboardingHeader />
-      <main className="flex-1 overflow-y-auto">
-        <div className="flex min-h-full flex-col items-center py-4">
-          <div className="my-auto w-[720px] bg-white rounded-2xl flex items-center justify-center py-[130px]">
+      <main className="flex-1 flex flex-col overflow-y-auto">
+        <div className="flex-1 flex flex-col items-center py-4">
+          <div className="flex-1 w-[720px] bg-white rounded-2xl flex items-center justify-center">
             <SigninForm />
           </div>
         </div>

--- a/src/pages/team-dashboard/ui/DashboardContent.tsx
+++ b/src/pages/team-dashboard/ui/DashboardContent.tsx
@@ -48,7 +48,7 @@ export function DashboardContent({ teamId }: DashboardContentProps) {
   }
 
   return (
-    <div className="mt-[40px] flex flex-1 min-h-0 gap-[54px]">
+    <div className="mt-[40px] flex min-h-0 gap-[54px]">
       <RetrospectColumn title="진행중" items={sortByDateAsc(inProgress)} teamId={teamId} />
       <RetrospectColumn title="임시저장" items={sortByDateAsc(draft)} teamId={teamId} />
       <RetrospectColumn title="종료" items={sortByDateAsc(completed)} teamId={teamId} />

--- a/src/pages/team-dashboard/ui/DashboardHeader.tsx
+++ b/src/pages/team-dashboard/ui/DashboardHeader.tsx
@@ -64,7 +64,7 @@ export function DashboardHeader({ teamId, teamName }: DashboardHeaderProps) {
         <Button
           variant="primary"
           size="md"
-          className="gap-[6px] px-[10px] py-[7.5px]"
+          className="gap-[6px] px-[10px] py-[7.5px] text-sub-title-5"
           onClick={() => setIsCreateOpen(true)}
         >
           <IcPlus className="h-[12px] w-[12px]" />

--- a/src/pages/team-dashboard/ui/DashboardHeader.tsx
+++ b/src/pages/team-dashboard/ui/DashboardHeader.tsx
@@ -64,7 +64,7 @@ export function DashboardHeader({ teamId, teamName }: DashboardHeaderProps) {
         <Button
           variant="primary"
           size="md"
-          className="gap-[6px] px-[10px] py-[7.5px] text-sub-title-5"
+          className="gap-[6px] px-[10px] py-[7.5px] text-sub-title-3"
           onClick={() => setIsCreateOpen(true)}
         >
           <IcPlus className="h-[12px] w-[12px]" />

--- a/src/pages/team-dashboard/ui/TeamDashboardPage.tsx
+++ b/src/pages/team-dashboard/ui/TeamDashboardPage.tsx
@@ -18,7 +18,7 @@ export function TeamDashboardPage() {
 
   return (
     <div className="flex h-full w-max min-w-full flex-col bg-grey-50">
-      <div className="mx-auto mt-[36px] flex min-h-0 w-full max-w-[960px] flex-1 flex-col px-5 pb-10">
+      <div className="mx-auto mt-[36px] flex min-h-0 w-full max-w-[980px] flex-1 flex-col pl-5 pb-10">
         <DashboardHeader teamId={currentTeam.retroRoomId} teamName={currentTeam.retroRoomName} />
         <ApiErrorBoundary resetKeys={[currentTeam.retroRoomId]}>
           <Suspense fallback={null}>

--- a/src/shared/ui/button/Button.tsx
+++ b/src/shared/ui/button/Button.tsx
@@ -3,7 +3,7 @@ import { forwardRef } from 'react';
 import { cn } from '@/shared/lib/cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center cursor-pointer font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3182F6]/30 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3182F6]/30 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -15,8 +15,8 @@ const buttonVariants = cva(
       size: {
         xs: 'h-6 px-2 rounded',
         sm: '',
-        md: 'h-[32px] px-[16.5px] text-sub-title-5 rounded-[8px]',
-        lg: 'h-[32px] px-[8px] text-sub-title-4 rounded-[8px]',
+        md: 'h-[32px] px-[16.5px] rounded-[8px]',
+        lg: 'h-[32px] px-[8px] rounded-[8px]',
         xl: 'h-[48px] rounded-[6px]',
       },
     },

--- a/src/shared/ui/calendar/Calendar.tsx
+++ b/src/shared/ui/calendar/Calendar.tsx
@@ -165,7 +165,7 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
     return (
       <div ref={ref} className="w-full">
         {/* Header: 월/년 + 네비게이션 */}
-        <div className="grid grid-cols-7 items-center px-[20px]">
+        <div className="grid grid-cols-7 items-center px-2">
           <span className="col-span-5 text-sub-title-0 text-grey-1000 truncate">
             {format(currentMonth, 'yyyy년 M월', { locale: ko })}
           </span>
@@ -188,11 +188,10 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
         {/* 요일 헤더 */}
         <div className="grid grid-cols-7 mt-[18px]">
           {WEEKDAYS.map((day) => (
-            <div
-              key={day}
-              className="flex h-[28px] items-center justify-center text-caption-3-medium text-grey-400"
-            >
-              {day}
+            <div key={day} className="flex h-[28px] items-center justify-center">
+              <span className="inline-flex w-[28px] justify-center text-caption-3-medium text-grey-400">
+                {day}
+              </span>
             </div>
           ))}
         </div>
@@ -213,11 +212,12 @@ const Calendar = forwardRef<HTMLDivElement, CalendarProps>(
             const isToday = isSameDay(date, new Date());
             const isFirstDay = index === 0;
 
-            // tabIndex 결정: focusedDate > selected > 첫 번째 날
             const shouldBeTabbable =
               isFocused ||
               (!focusedDate && isSelected) ||
               (!focusedDate && !selected && isFirstDay);
+
+            const dow = getDay(date);
 
             return (
               <div key={date.toISOString()} className="flex h-[28px] items-center justify-center">

--- a/src/widgets/retrospective-detail-panel/ui/RetrospectiveDetailPanel.tsx
+++ b/src/widgets/retrospective-detail-panel/ui/RetrospectiveDetailPanel.tsx
@@ -653,7 +653,7 @@ function RetrospectiveDetailPanel({
                 <button
                   type="button"
                   onClick={handleAssistantGenerate}
-                  className="mt-3 flex cursor-pointer items-center gap-2 text-grey-500"
+                  className="mt-3 flex cursor-pointer items-center gap-2 rounded-[4px] px-2 py-1 text-grey-500 hover:bg-grey-100"
                 >
                   <IcRefresh className="h-4 w-4" />
                   <span className="text-sub-title-4">다시 생성</span>

--- a/src/widgets/sidebar/ui/SidebarListHeader.tsx
+++ b/src/widgets/sidebar/ui/SidebarListHeader.tsx
@@ -16,7 +16,7 @@ export function SidebarListHeader({ title }: SidebarListHeaderProps) {
 
   return (
     <div className="h-[38px] pl-[14px] py-[7px] flex items-center justify-between">
-      <span className="text-sub-title-4 text-grey-600 truncate">{title}</span>
+      <span className="text-sub-title-4 text-grey-700 truncate">{title}</span>
       <div className="relative group">
         {!isDropdownOpen && (
           <IcTooltip className="absolute bottom-[calc(100%+8px)] left-1/2 -translate-x-1/2 pointer-events-none opacity-0 group-hover:opacity-100" />


### PR DESCRIPTION
## 요약

- 서비스 출시 전 긴급 QA 피드백 반영
- 인증, 회고 상세, 팀 대시보드, 사이드바 등 전 페이지 스타일 및 버그 수정

## 변경 사항

- fix(auth): 신규 회원 온보딩 리다이렉트 버그 수정
- fix(auth): 탈퇴 유저 재가입 시 온보딩 진입 불가 버그 수정
- fix(auth): 로그인/온보딩 페이지 본문 영역 전체 높이 채우기
- fix(auth): 로그인 페이지 모바일 횡스크롤 및 소형 화면 버튼 밀림 수정
- chore: Button에서 font-semibold 및 size별 text 토큰 제거, 각 사용처에 text 클래스 직접 명시
- fix: StepIndicator span을 div로 변경하여 mb-1 적용
- fix(retrospective-detail): 완료된 회고 상세 페이지 레이아웃 및 UX 개선
- fix(team-dashboard): 회고 카드 및 대시보드 레이아웃 정렬 개선
- fix: 사이드바·캘린더·어시스턴트 버튼 스타일 수정

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [ ] 문서 업데이트 필요 여부 확인

Closes #185